### PR TITLE
Use signed ints instead of unsigned ints

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -169,7 +169,7 @@ function encodeMetadataRequest(clientId, correlationId, topics) {
     });
     return encodeRequestWithLength(request.make());
 }
-var i=0;
+
 function decodeMetadataResponse(resp) {
     var brokers = {}, out = {}, topics = {}, errors = [];
     Binary.parse(resp)


### PR DESCRIPTION
This resolves #14

The kafka protocol dictates the use of signed ints, using unsigned ints causes some parsing errors. Most notably if the key in a message is null.

There are also some additional minor fixes included:
- Removed a top level `var i=0;` that wasn't in use
- Added the message `key` value to the emitted message object
