### PR TITLE
Add support and test for sending raw buffer messages into BufferMaker

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -348,7 +348,7 @@ function encodeMessage(message) {
         .Int8(message.attributes)
         .Int32BE(message.key.length)
         .string(message.key)
-        .Int32BE(Buffer.byteLength(message.value))
+        .Int32BE(Buffer.isBuffer(message.value) ? message.value.length : Buffer.byteLength(message.value))
         .string(message.value).make();
     var crc = crc32.signed(m);
     return new Buffermaker()

--- a/test/test.producer.js
+++ b/test/test.producer.js
@@ -29,6 +29,14 @@ describe('Producer', function () {
             }); 
         });
 
+        it('should send buffer message successfully', function (done) {
+            var message = new Buffer('hello kafka');
+            producer.send([{ topic: '_exist_topic_3_test', messages: message }], function (err, message) {
+                message.should.be.ok;
+                done(err);
+            }); 
+        });
+
         it('should support multi messages in one topic', function (done) {
             producer.send([{ topic: '_exist_topic_3_test', messages: ['hello kafka', 'hello kafka'] }], function (err, message) {
                 message.should.be.ok;


### PR DESCRIPTION
Hi, I'm using this in a project and need to be able to send raw Buffer objects (binary encoded) and have them properly encoded into the message. This patch allows that and comes with a test.
