### PR TITLE
Improve consumer#addTopics

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -177,6 +177,7 @@ Consumer.prototype.addTopics = function (topics, cb) {
             if (err) return cb && cb(err, added);
 
             var payloads = self.buildPayloads(topics);
+            var reFetch = !self.payloads.length;
             // update offset of topics that will be added
             self.fetchOffset(payloads, function (err, offsets) {
                 if (err) return cb(err);
@@ -184,6 +185,8 @@ Consumer.prototype.addTopics = function (topics, cb) {
                     p.offset = offsets[p.topic][p.partition];
                     self.payloads.push(p);
                 });
+                self.updateOffsets(offsets);
+                if (reFetch) self.fetch();
                 cb && cb(null, added);
             });
         }


### PR DESCRIPTION
Resend a fetch request after addTopics if the consumer isn't consuming. Fix issue #61.
