### PR TITLE
Add retries for refreshMetadata

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -225,20 +225,31 @@ Client.prototype.nextPartition = (function cycle() {
 
 Client.prototype.refreshBrokers = function (brokerMetadata) {
     this.brokerMetadata = brokerMetadata;
-    Object.keys(this.brokers).filter(function (k) {
-        return !~_.values(brokerMetadata).map(function (b) { return b.host + ':' + b.port }).indexOf(k);
-    }).forEach(function (deadKey) {
-        delete this.brokers[deadKey];
-    }.bind(this));
+    deleteDeadBrokers(this.brokers);
+    deleteDeadBrokers(this.longpollingBrokers);
+    function deleteDeadBrokers (brokers) {
+        Object.keys(brokers).filter(function (k) {
+            return !~_.values(brokerMetadata).map(function (b) { return b.host + ':' + b.port }).indexOf(k);
+        }).forEach(function (deadKey) {
+            delete brokers[deadKey];
+        }.bind(this));
+    }
 }
 
-Client.prototype.refreshMetadata = function (topicNames, cb) {
+Client.prototype.refreshMetadata = function (topicNames, retry, cb) {
     var self = this;
-    topicNames = topicNames || Object.keys(self.topicMetadata);
-    if (!topicNames.length) return;
+    topicNames = topicNames;
+    if (!topicNames.length) return cb();
     self.loadMetadataForTopics(topicNames, function (err, resp) {
-        if (err) return cb(err);
-        if (resp[1].error) return cb(resp[1].error);
+        var error = err || resp[1].error;
+        if (error) {
+            retry++;
+            if (retry === 10) cb(error);
+            else setTimeout(function () {
+                self.refreshMetadata(topicNames, retry, cb)
+            }, 1000);
+            return;
+        }
         self.updateMetadatas(resp);
         cb();
     });

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -78,7 +78,7 @@ Consumer.prototype.connect = function () {
         var topicNames = self.payloads.map(function (p) {
             return p.topic;
         });
-        this.refreshMetadata(topicNames, function () {
+        this.refreshMetadata(topicNames, 0, function () {
             self.fetch();
         });
     });

--- a/test/test.consumer.js
+++ b/test/test.consumer.js
@@ -69,8 +69,10 @@ describe('Consumer', function () {
 
         it('should emit offsetOutOfRange when offset out of range', function (done) {
             var topics = [ { topic: '_exist_topic_1_test', offset: 100 } ],
-                options = { fromOffset: true, autoCommit: false }, 
+                options = { fromOffset: true, autoCommit: false },
                 count = 0;
+
+            var client = new Client();
             var consumer = new Consumer(client, topics, options);
             consumer.on('offsetOutOfRange', function (topic) {
                 topic.topic.should.equal('_exist_topic_1_test');

--- a/test/test.zookeeper.js
+++ b/test/test.zookeeper.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var libPath = process.env['kafka-cov'] ? '../lib-cov/' : '../lib/',
-    Zookeeper = require(libPath + 'zookeeper');
+    Zookeeper = require(libPath + 'zookeeper').Zookeeper;
 
 var zk;
 


### PR DESCRIPTION
When broker(s) recovery from shutdown, it will immediately come into zookeeper, which will result in a `brokersChanged` event in kafka-node. When kafka-node client get the event, it will refresh the metadata, but it always need several seconds to wait for the brokers actually be available, so we add a retry once per second if it fails to refresh, so far the max retries is 10. Related to issue #60.
