### PR TITLE
add support to fetch from specific offset in Consumer.addTopics

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -163,7 +163,8 @@ Consumer.prototype.fetchOffset = function (payloads, cb) {
     this.client.sendOffsetFetchRequest(this.options.groupId, payloads, cb);
 }
 
-Consumer.prototype.addTopics = function (topics, cb) {
+Consumer.prototype.addTopics = function (topics, cb, fromOffset) {
+    fromOffset = !!fromOffset;
     var self = this;
     if (!this.ready) {
         setTimeout(function () {
@@ -171,13 +172,32 @@ Consumer.prototype.addTopics = function (topics, cb) {
             , 100);
         return;
     }
+
+    // The default is that the topics is a string array of topic names
+    var topicNames = topics;
+
+    // If the topics is actually an object and not string we assume it is an array of payloads
+    if (typeof topics[0] === 'object') {
+        topicNames = topics.map(function (p) { return p.topic; })
+    }
+
     this.client.addTopics(
-        topics,
+        topicNames,
         function (err, added) {
             if (err) return cb && cb(err, added);
 
             var payloads = self.buildPayloads(topics);
             var reFetch = !self.payloads.length;
+
+            if (fromOffset) {
+                payloads.forEach(function (p) {
+                    self.payloads.push(p);
+                });
+                if (reFetch) self.fetch();
+                cb && cb(null, added);
+                return;
+            }
+
             // update offset of topics that will be added
             self.fetchOffset(payloads, function (err, offsets) {
                 if (err) return cb(err);


### PR DESCRIPTION
I wanted to suggest this change so a call to `Consumer.addTopics` would not automatically make a fetchOffsetRequest, but rather give the possibility to the user to specify an offset.
What do you think? is it problematic?
