### PR TITLE
replaced "console.log" with an optional dependence on "debug."

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,3 +1,5 @@
+var debug = require('./debug');
+
 var Cache = function (expire) {
     this._expire = expire || 5000; // ms
     this._granularity = 1000; // ms
@@ -25,7 +27,7 @@ Cache.prototype.get = function (key) {
         return this._store[key];
 };
 Cache.prototype.clean = function () {
-    console.log(this._expireQueue);
+    debug(this._expireQueue);
     var that = this;
     var keys = this._expireQueue.shift();
     keys && keys.forEach(function (key) {

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -6,7 +6,9 @@ var util = require('util'),
     Client = require('./client'),
     protocol = require('./protocol'),
     Offset = require('./offset'),
-    errors = require('./errors')
+    errors = require('./errors'),
+    debug = require('./debug');
+
 
 var DEFAULTS = {
     groupId: 'kafka-node-group',
@@ -71,7 +73,7 @@ Consumer.prototype.connect = function () {
     });
 
     this.client.on('close', function () {
-        console.log('close');
+        debug('close');
     });
 
     this.client.on('brokersChanged', function () {

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,10 @@
+'use strict';
+var debug = null;
+
+try {
+	debug = require('debug')('kafka-node');
+} catch( err ) {
+	debug = function() {};
+}
+
+module.exports = debug;

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -10,7 +10,8 @@ var util = require('util'),
     async = require("async"),
     errors = require('./errors'),
     zk = require('./zookeeper'),
-    ZookeeperConsumerMappings = zk.ZookeeperConsumerMappings;
+    ZookeeperConsumerMappings = zk.ZookeeperConsumerMappings,
+    debug = require('./debug');    
 
 var DEFAULTS = {
     groupId: 'kafka-node-group',
@@ -129,11 +130,11 @@ HighLevelConsumer.prototype.connect = function () {
             self.topicPayloads = [];
             self.rebalanceAttempt(oldTopicPayloads, function (err) {
                 if (err) {
-                    console.log(err);
+                    debug(err);
                     setTimeout(function () {
                         self.rebalanceAttempt(oldTopicPayloads, function (err) {
                             if (err) {
-                                console.log(err);
+                                debug(err);
                                 setTimeout(function () {
                                     self.rebalanceAttempt(oldTopicPayloads, function (err) {
                                         if (err) {
@@ -176,7 +177,7 @@ HighLevelConsumer.prototype.connect = function () {
         if (self.ready) {
             rebalance();
         }
-        else console.log("consumersChanged not ready");
+        else debug("consumersChanged not ready");
     });
     this.client.zk.on('error', function (err) {
         self.emit('error', err);
@@ -185,7 +186,7 @@ HighLevelConsumer.prototype.connect = function () {
         if (self.ready) {
             rebalance();
         }
-        else console.log("brokersChanged not ready");
+        else debug("brokersChanged not ready");
     });
 
     this.client.on('error', function (err) {
@@ -193,7 +194,7 @@ HighLevelConsumer.prototype.connect = function () {
     });
 
     this.client.on('close', function () {
-        console.log('close');
+        debug('close');
     });
 
     this.client.on('brokersChanged', function () {
@@ -241,12 +242,12 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     // Do the rebalance.....
     var consumerPerTopicMap;
     var newTopicPayloads = [];
-    console.log("HighLevelConsumer %s is attempting to rebalance", self.id);
+    debug("HighLevelConsumer %s is attempting to rebalance", self.id);
     async.series([
 
             // Stop fetching data and commit offsets
             function (callback) {
-                console.log("HighLevelConsumer %s stopping data read during rebalance", self.id);
+                debug("HighLevelConsumer %s stopping data read during rebalance", self.id);
                 self.stop(function () {
                     callback();
                 })
@@ -254,7 +255,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Assemble the data
             function (callback) {
-                console.log("HighLevelConsumer %s assembling data for rebalance", self.id);
+                debug("HighLevelConsumer %s assembling data for rebalance", self.id);
                 self.client.zk.getConsumersPerTopic(self.options.groupId, function (err, obj) {
                     if (err) {
                         callback(err);
@@ -268,7 +269,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Release current partitions
             function (callback) {
-                console.log("HighLevelConsumer %s releasing current partitions during rebalance", self.id);
+                debug("HighLevelConsumer %s releasing current partitions during rebalance", self.id);
                 async.each(oldTopicPayloads, function (tp, cbb) {
                     if (tp['partition'] !== undefined) {
                         self.client.zk.deletePartitionOwnership(self.options.groupId, tp['topic'], tp['partition'], function (err) {
@@ -289,7 +290,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Reblannce
             function (callback) {
-                console.log("HighLevelConsumer %s determining the partitions to own during rebalance", self.id);
+                debug("HighLevelConsumer %s determining the partitions to own during rebalance", self.id);
                 for (var topic in consumerPerTopicMap.consumerTopicMap[self.id]) {
                     var topicToAdd = consumerPerTopicMap.consumerTopicMap[self.id][topic];
                     var numberOfConsumers = consumerPerTopicMap.topicConsumerMap[topicToAdd].length;
@@ -320,7 +321,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
             // Update ZK with new ownership
             function (callback) {
                 if (newTopicPayloads.length) {
-                    console.log("HighLevelConsumer %s gaining ownership of partitions during rebalance", self.id);
+                    debug("HighLevelConsumer %s gaining ownership of partitions during rebalance", self.id);
                     async.each(newTopicPayloads, function (tp, cbb) {
                         if (tp['partition'] !== undefined) {
                             self.client.zk.addPartitionOwnership(self.id, self.options.groupId, tp['topic'], tp['partition'], function (err) {
@@ -341,7 +342,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
                     });
                 }
                 else {
-                    console.log("HighLevelConsumer %s has been assigned no partitions during rebalance", self.id);
+                    debug("HighLevelConsumer %s has been assigned no partitions during rebalance", self.id);
                     callback();
                 }
             },
@@ -353,11 +354,11 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
             }],
         function (err) {
             if (err) {
-                console.log("HighLevelConsumer %s rebalance attempt failed", self.id);
+                debug("HighLevelConsumer %s rebalance attempt failed", self.id);
                 cb(err);
             }
             else {
-                console.log("HighLevelConsumer %s rebalance attempt was successful", self.id);
+                debug("HighLevelConsumer %s rebalance attempt was successful", self.id);
                 cb();
             }
         });

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -3,7 +3,8 @@
 var zookeeper = require('node-zookeeper-client')
     , util = require('util')
     , async = require("async")
-    , EventEmiter = require('events').EventEmitter;
+    , EventEmiter = require('events').EventEmitter
+    , debug = require('./debug');
 
 /**
  * Provides kafka specific helpers for talking with zookeeper
@@ -77,7 +78,7 @@ Zookeeper.prototype.registerConsumer = function (groupId, consumerId, payloads, 
                         callback(error);
                     }
                     else {
-                        console.log('Node: %s was created.', path + '/ids/' + consumerId);
+                        debug('Node: %s was created.', path + '/ids/' + consumerId);
                         cb();
                     }
                 });
@@ -104,7 +105,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
                         return;
                     }
                     else {
-                        console.log('Children are: %j.', children);
+                        debug('Children are: %j.', children);
                         consumers = children;
                         async.each(children, function (consumer, cbb) {
                             var path = consumersPath + '/' + consumer;
@@ -132,7 +133,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
 
                                             cbb();
                                         } catch (e) {
-                                            console.log(e);
+                                            debug(e);
                                             callback(new Error("Unable to assemble data"));
                                         }
                                     }
@@ -182,7 +183,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
             }],
         function (err) {
             if (err) {
-                console.log(err);
+                debug(err);
                 cb(err);
             }
             else cb(null, consumerPerTopicMap);
@@ -203,7 +204,7 @@ Zookeeper.prototype.listBrokers = function (cb) {
         },
         function (error, children) {
             if (error) {
-                console.log('Failed to list children of node: %s due to: %s.', path, error);
+                debug('Failed to list children of node: %s due to: %s.', path, error);
                 that.emit('error', error);
                 return;
             }
@@ -265,7 +266,7 @@ Zookeeper.prototype.topicExists = function (topic, cb, watch) {
     this.client.exists(
         path,
         function (event) {
-            console.log('Got event: %s.', event);
+            debug('Got event: %s.', event);
             if (watch)
                 self.topicExists(topic, cb);
         },
@@ -285,7 +286,7 @@ Zookeeper.prototype.deletePartitionOwnership = function (groupId, topic, partiti
             if (error)
                 cb(error);
             else {
-                console.log("Removed partition ownership %s", path);
+                debug("Removed partition ownership %s", path);
                 cb();
             }
         }
@@ -349,7 +350,7 @@ Zookeeper.prototype.addPartitionOwnership = function (consumerId, groupId, topic
                         callback(error);
                     }
                     else if (stat){
-                        console.log('Gained ownership of %s by %s.', path, consumerId);
+                        debug('Gained ownership of %s by %s.', path, consumerId);
                         callback();
                     }
                     else{

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "lodash": "~2.2.1"
     },
     "devDependencies": {
+        "debug": "^2.0.0",
         "mocha": "^1.18.2",
         "should": "~1.2.2",
         "line-by-line": "~0.1.1",


### PR DESCRIPTION
I replaced the direct calls to "console" with a wrapper around "debug" in lib/debug.js. If "debug" is not found, it will just eat log messages.

If you would rather, I can have the lack of a dependence on "debug" to revert to use "console.log" instead of an empty function.