### PR TITLE
fix HighLevelProducer.createTopics

### DIFF
--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -91,7 +91,7 @@ HighLevelProducer.prototype.createTopics = function (topics, async, cb) {
         }, 100);
         return;
     }
-    topics = typeof topic === 'string' ? [topics] : topics;
+    topics = typeof topics === 'string' ? [topics] : topics;
     if (typeof async === 'function' && typeof cb === 'undefined') {
         cb = async;
         async = true;


### PR DESCRIPTION
Fixes error in `HighLevelProducer#createTopics` when `topics` parameter is single topic name.