### PR TITLE
fromOffset no longer dropped in addTopics if consumer is not yet ready

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -170,7 +170,7 @@ Consumer.prototype.addTopics = function (topics, cb, fromOffset) {
     var self = this;
     if (!this.ready) {
         setTimeout(function () {
-                self.addTopics(topics,cb) }
+                self.addTopics(topics, cb, fromOffset) }
             , 100);
         return;
     }


### PR DESCRIPTION
If the consumer is not in ready state, the addTopics() method will try again in 100ms. However the fromOffset argument was accidentally dropped from the retry.