### PR TITLE
Handle snappy & gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,17 @@ var kafka = require('kafka-node'),
    topic: 'topicName',
    messages: ['message body'],// multi messages should be a array, single message can be just a string
    partition: '0', //default 0
+   attributes: 2, // default: 0
 }
 ```
 
 * `cb`: **Function**, the callback
+
+`attributes` controls compression of the message set. It supports the following values:
+
+* `0`: No compression
+* `1`: Compress using GZip
+* `2`: Compress using snappy
 
 Example:
 
@@ -183,7 +190,9 @@ producer.createTopics(['t'], function (err, data) {});// Simply omit 2nd arg
     // The maximum bytes to include in the message set for this partition. This helps bound the size of the response.
     fetchMaxBytes: 1024 * 10, 
     // If set true, consumer will fetch message from the given offset in the payloads 
-    fromOffset: false
+    fromOffset: false,
+    // If set to 'buffer', values will be returned as raw buffer objects.
+    encoding: 'utf8'
 }
 ```
 Example:

--- a/lib/client.js
+++ b/lib/client.js
@@ -100,7 +100,7 @@ Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs
             }
 
             if (type === 'message') {
-                consumer.emit('message', value);
+                consumer.handleMessage(value);
             } else {
                 consumer.emit('done', value);
             }

--- a/lib/codec/index.js
+++ b/lib/codec/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var zlib = require('zlib'),
+    snappyCodec = require('./snappy');
+
+var gzipCodec = {
+    encode: zlib.gzip,
+    decode: zlib.gunzip
+};
+
+var codecs = [
+    null,
+    gzipCodec,
+    snappyCodec
+];
+
+function getCodec(attributes) {
+    return codecs[attributes & 3] || null;
+}
+
+module.exports = getCodec;

--- a/lib/codec/snappy.js
+++ b/lib/codec/snappy.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var async = require('async'),
+    snappy = require('snappy');
+
+var SNAPPY_MAGIC_BYTES = [130, 83, 78, 65, 80, 80, 89, 0],
+    SNAPPY_MAGIC_BYTES_LEN = SNAPPY_MAGIC_BYTES.length,
+    SNAPPY_MAGIC = new Buffer(SNAPPY_MAGIC_BYTES).toString('hex');
+
+function isChunked(buffer) {
+    var prefix = buffer.toString('hex', 0, SNAPPY_MAGIC_BYTES_LEN);
+    return prefix === SNAPPY_MAGIC;
+}
+
+// Ported from:
+// https://github.com/Shopify/sarama/blob/a3e2437d6d26cda6b2dc501dbdab4d3f6befa295/snappy.go
+function decodeSnappy(buffer, cb) {
+    if (isChunked(buffer)) {
+        var pos = 16,
+            max = buffer.length,
+            encoded = [],
+            size;
+
+        while (pos < max) {
+            size = buffer.readUInt32BE(pos);
+            pos += 4;
+            encoded.push(buffer.slice(pos, pos + size));
+            pos += size;
+        }
+        return async.mapSeries(encoded, snappy.uncompress,
+          function(err, decodedChunks) {
+            if (err) return cb(err);
+            return cb(null, Buffer.concat(decodedChunks));
+          }
+        );
+    }
+    return snappy.uncompress(buffer, cb);
+}
+
+exports.encode = snappy.compress;
+exports.decode = decodeSnappy;

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -19,7 +19,8 @@ var DEFAULTS = {
     fetchMaxWaitMs: 100,
     fetchMinBytes: 1,
     fetchMaxBytes: 1024 * 1024,
-    fromOffset: false
+    fromOffset: false,
+    encoding: 'utf8'
 };
 
 var nextId = (function () {
@@ -42,6 +43,7 @@ var Consumer = function (client, topics, options) {
     this.id = nextId();
     this.payloads = this.buildPayloads(topics);
     this.connect();
+    this.encoding = this.options.encoding;
 }
 util.inherits(Consumer, events.EventEmitter);
 
@@ -122,6 +124,13 @@ Consumer.prototype.init = function () {
         });
     });
 }
+
+Consumer.prototype.handleMessage = function (message) {
+    if (this.encoding !== 'buffer') {
+        message.value = message.value.toString(this.encoding);
+    }
+    this.emit('message', message);
+};
 
 /*
  * Update offset info in current payloads

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -3,10 +3,13 @@
 var util = require('util'),
     events = require('events'),
     _ = require('lodash'),
+    async = require('async'),
     Client = require('./client'),
     protocol = require('./protocol'),
+    getCodec = require('./codec'),
     Message = protocol.Message,
     ProduceRequest = protocol.ProduceRequest,
+    encodeMessageSet = protocol.encodeMessageSet,
     DEFAULTS = {
         requireAcks: 1,
         ackTimeoutMs: 100
@@ -67,18 +70,39 @@ Producer.prototype.connect = function () {
  * @param {Producer~sendCallback} cb A function to call once the send has completed
  */
 Producer.prototype.send = function (payloads, cb) {
-    this.client.sendProduceRequest(this.buildPayloads(payloads), this.requireAcks, this.ackTimeoutMs, cb);
+    var client = this.client,
+        requireAcks = this.requireAcks,
+        ackTimeoutMs = this.ackTimeoutMs;
+    this.buildPayloads(payloads, function(error, payloads) {
+        if (error) return cb(error);
+        client.sendProduceRequest(payloads, requireAcks, ackTimeoutMs, cb);
+    });
 }
 
-Producer.prototype.buildPayloads = function (payloads) {
-    return payloads.map(function (p) {
+Producer.prototype.buildPayloads = function (payloads, cb) {
+    async.mapSeries(payloads, function (p, onRequest) {
+        var messages, innerSet, codec;
+
+        codec = getCodec(p.attributes);
         p.partition = p.partition || 0;
-        var messages = _.isArray(p.messages) ? p.messages : [p.messages];
-        messages = messages.map(function (message) {
-            return new Message(0,0,'',message);
+        messages = _.isArray(p.messages) ? p.messages : [p.messages];
+
+        messages = messages.map(function(message) {
+            return new Message(0, 0, '', message);
         });
-        return new ProduceRequest(p.topic, p.partition, messages);
-    });
+
+        if (!codec) {
+            onRequest(null, new ProduceRequest(p.topic, p.partition, messages));
+        } else {
+            innerSet = encodeMessageSet(messages);
+            codec.encode(innerSet, function(error, message) {
+                if (error) return onRequest(error);
+                onRequest(null, new ProduceRequest(p.topic, p.partition, [
+                    new Message(0, p.attributes, '', message)
+                ]));
+            });
+        }
+    }, cb);
 }
 
 Producer.prototype.createTopics = function (topics, async, cb) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -5,6 +5,7 @@ var Binary = require('binary'),
     _  = require('lodash'),
     crc32 = require('buffer-crc32'),
     protocol = require('./protocol_struct'),
+    getCodec = require('../codec'),
     KEYS = protocol.KEYS,
     REQUEST_TYPE = protocol.REQUEST_TYPE,
     ERROR_CODE = protocol.ERROR_CODE,
@@ -148,13 +149,26 @@ function decodeMessageSet(topic, partition, messageSet, cb, maxTickMessages) {
                 if (vars.value !== -1) {
                     cur += vars.value;
                     this.buffer('value', vars.value);
-                    vars.value = vars.value.toString();
                 }
 
                 if (!vars.partial && vars.offset !== null) {
                     messageCount++;
-                    cb && cb(null, 'message', { topic: topic, value: vars.value, offset: vars.offset, partition: partition, key: vars.key });
                     set.push(vars.offset);
+                    if (!cb) return;
+                    var codec = getCodec(vars.attributes);
+                    if (!codec) {
+                        return cb(null, 'message', {
+                            topic: topic,
+                            value: vars.value,
+                            offset: vars.offset,
+                            partition: partition,
+                            key: vars.key
+                        });
+                    }
+                    codec.decode(vars.value, function(error, inlineMessageSet) {
+                        if (error) return; // Not sure where to report this
+                        decodeMessageSet(topic, partition, inlineMessageSet, cb, maxTickMessages);
+                    });
                 }
             });
         // Defensive code around potential denial of service
@@ -505,3 +519,4 @@ exports.encodeProduceRequest = encodeProduceRequest;
 exports.decodeProduceResponse = decodeProduceResponse;
 exports.encodeOffsetRequest = encodeOffsetRequest;
 exports.decodeOffsetResponse = decodeOffsetResponse;
+exports.encodeMessageSet = encodeMessageSet;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lodash": "~2.2.1",
     "node-uuid": "1.4.1",
     "node-zookeeper-client": "0.2.0",
-    "retry": "^0.6.1"
+    "retry": "^0.6.1",
+    "snappy": "^3.0.4"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/test/test.offset.js
+++ b/test/test.offset.js
@@ -7,8 +7,10 @@ var libPath = process.env['kafka-cov'] ? '../lib-cov/' : '../lib/',
 
 var client, producer, offset;
 
+var host = process.env['KAFKA_TEST_HOST'] || '';
+
 before(function (done) {
-    client = new Client();
+    client = new Client(host);
     producer = new Producer(client);
     producer.on('ready', function () {
         producer.createTopics(['_exist_topic_3_test'], false, function (err, created) {


### PR DESCRIPTION
Support for handling compression in both consumer and producer. On the consumer side it's handled transparently, for producers there's a new property in the payload (`attributes`) that can be set to 0, 1, or 2 (defaults to 0).

This PR also adds support for consumer.encoding which can be used to control how values are returned. Previously it was only possible to retrieve a stringified version of the value which destroyed binary encodings (like msgpack). The default is "utf8" which should match the previous behavior.

Fixes https://github.com/SOHU-Co/kafka-node/issues/27