### PR TITLE
improve callback queue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -209,7 +209,7 @@ Client.prototype.loadMetadataForTopics = function (topics, cb) {
         return cb(new errors.BrokerNotAvailableError('Broker not available'));
     }
 
-    this.cbqueue[correlationId] = [protocol.decodeMetadataResponse, cb];
+    this.queueCallback(broker, correlationId, [protocol.decodeMetadataResponse, cb]);
     broker && broker.write(request);
 }
 
@@ -401,7 +401,7 @@ Client.prototype.sendToBroker = function (payloads, encoder, decoder, cb) {
             if (broker.waitting) continue;
             broker.waitting = true;
         }
-        this.cbqueue[correlationId] = [decoder, cb];
+        this.queueCallback(broker, correlationId, [decoder, cb]);
         broker && broker.write(request);
     }
 }
@@ -479,20 +479,29 @@ Client.prototype.brokerForLeader = function (leader, longpolling) {
 Client.prototype.createBroker = function connect(host, port, longpolling) {
     var self = this;
     var socket = net.createConnection(port, host);
+    var attempts = 0;
     socket.addr = host + ':' + port;
     socket.host = host;
     socket.port = port;
     if (longpolling) socket.longpolling = true;
 
     socket.on('connect', function () {
-        this.error = false;
+        this.error = null;
+        attempts = 0;
         self.emit('connect');
     });
     socket.on('error', function (err) {
+        this.error = err;
         self.emit('error', err);
     });
-    socket.on('close', function (err) {
-        self.emit('close');
+    socket.on('close', function (had_error) {
+        self.emit('close', this);
+        if (had_error) {
+            self.clearCallbackQueue(this, this.error);
+        }
+        else {
+            self.clearCallbackQueue(this, new errors.BrokerNotAvailableError('Broker not available'));
+        }
         retry(this);
     });
     socket.on('end', function () {
@@ -508,7 +517,6 @@ Client.prototype.createBroker = function connect(host, port, longpolling) {
     function retry(s) {
         if(s.retrying || s.closing) return;
         s.retrying = true;
-        s.error = true;
         s.retryTimer = setTimeout(function () {
             s.retrying = false;
             s.connect(s.port, s.host);
@@ -523,11 +531,9 @@ Client.prototype.handleReceivedData = function (socket) {
             correlationId = vars.correlationId;
         if (socket.buffer.length >= size) {
             var resp = socket.buffer.slice(0, size);
-            var handlers = this.cbqueue[correlationId],
+            var handlers = this.unqueueCallback(socket, correlationId),
                 decoder = handlers[0],
                 cb = handlers[1];
-            // Delete callback functions after finish a request
-            delete this.cbqueue[correlationId];
             cb.call(this, null, decoder(resp));
             socket.buffer = socket.buffer.slice(size);
             if (socket.longpolling) socket.waitting = false;
@@ -536,6 +542,68 @@ Client.prototype.handleReceivedData = function (socket) {
     if (socket.buffer.length)
         setImmediate(function () { this.handleReceivedData(socket);}.bind(this));
 }
+
+/**
+ * Helper to get id of socket used in callback queues
+ */
+function socketId(socket) {
+    return socket.host + ':' + socket.port;
+}
+
+Client.prototype.queueCallback = function (broker, id, data) {
+    var brokerId = socketId(broker);
+    var queue;
+
+    if (this.cbqueue.hasOwnProperty(brokerId)) {
+        queue = this.cbqueue[brokerId];
+    }
+    else {
+        queue = {};
+        this.cbqueue[brokerId] = queue;
+    }
+
+    queue[id] = data;
+};
+
+Client.prototype.unqueueCallback = function (broker, id) {
+    var brokerId = socketId(broker);
+    if (!this.cbqueue.hasOwnProperty(brokerId)) {
+        return null;
+    }
+
+    var queue = this.cbqueue[brokerId];
+    if (!queue.hasOwnProperty(id)) {
+        return null;
+    }
+
+    var result = queue[id];
+
+    // cleanup socket queue
+    delete queue[id];
+    if (!Object.keys(queue).length) {
+        delete this.cbqueue[brokerId];
+    }
+
+    return result;
+};
+
+Client.prototype.clearCallbackQueue = function (broker, error) {
+    var brokerId = socketId(broker);
+    if (!this.cbqueue.hasOwnProperty(brokerId)) {
+        return;
+    }
+
+    var queue = this.cbqueue[brokerId];
+    var correlationId;
+    for (correlationId in queue) {
+        if (queue.hasOwnProperty(correlationId)) {
+            var handlers = queue[correlationId];
+            var cb = handlers[1];
+            cb(error);
+        }
+    }
+    delete this.cbqueue[brokerId];
+};
 
 module.exports = Client;
 


### PR DESCRIPTION
The addition solves the problem of never-called callback function passed to, for example, `Producer#send`.

Before there was no connection between socket (connection to broker) and callbacks passed to methods which interact with Broker and expect response. So once Broker died (OOM, stopped by supervisor, whatever), client started infinite reconnect attempts.

The point is callback should be called once we get socket error like `ECONNRESET` / `ECONNREFUSED`. This way module user can handle error in place where he calls some method (instead of handling client 'error' or 'close' events).