### PR TITLE
More improments for callabck queue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -479,7 +479,6 @@ Client.prototype.brokerForLeader = function (leader, longpolling) {
 Client.prototype.createBroker = function connect(host, port, longpolling) {
     var self = this;
     var socket = net.createConnection(port, host);
-    var attempts = 0;
     socket.addr = host + ':' + port;
     socket.host = host;
     socket.port = port;
@@ -487,7 +486,6 @@ Client.prototype.createBroker = function connect(host, port, longpolling) {
 
     socket.on('connect', function () {
         this.error = null;
-        attempts = 0;
         self.emit('connect');
     });
     socket.on('error', function (err) {
@@ -526,18 +524,20 @@ Client.prototype.createBroker = function connect(host, port, longpolling) {
 }
 
 Client.prototype.handleReceivedData = function (socket) {
-        var vars = Binary.parse(socket.buffer).word32bu('size').word32bu('correlationId').vars,
-            size = vars.size + 4,
-            correlationId = vars.correlationId;
-        if (socket.buffer.length >= size) {
-            var resp = socket.buffer.slice(0, size);
-            var handlers = this.unqueueCallback(socket, correlationId),
-                decoder = handlers[0],
-                cb = handlers[1];
-            cb.call(this, null, decoder(resp));
-            socket.buffer = socket.buffer.slice(size);
-            if (socket.longpolling) socket.waitting = false;
-        } else { return }
+    var vars = Binary.parse(socket.buffer).word32bu('size').word32bu('correlationId').vars,
+        size = vars.size + 4,
+        correlationId = vars.correlationId;
+    if (socket.buffer.length >= size) {
+        var resp = socket.buffer.slice(0, size);
+        var handlers = this.unqueueCallback(socket, correlationId);
+
+        if (!handlers) return;
+        var decoder = handlers[0],
+            cb = handlers[1];
+        cb.call(this, null, decoder(resp));
+        socket.buffer = socket.buffer.slice(size);
+        if (socket.longpolling) socket.waitting = false;
+    } else { return }
 
     if (socket.buffer.length)
         setImmediate(function () { this.handleReceivedData(socket);}.bind(this));

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -132,8 +132,12 @@ Consumer.prototype.init = function () {
  */
 Consumer.prototype.updateOffsets = function (topics, initing) {
     this.payloads.forEach(function (p) {
-        if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined)
-            p.offset = topics[p.topic][p.partition] + 1;
+        if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined) {
+          var offset = topics[p.topic][p.partition];
+          if (offset === -1) offset = 0;
+          if (!initing) p.offset = offset + 1;
+          else p.offset = offset;
+        }
     });
 
     if (this.options.autoCommit && !initing) this.autoCommit();
@@ -149,12 +153,8 @@ function autoCommit(force, cb) {
 
     var payloads = this.payloads;
     if (this.pausedPayloads) payloads = payloads.concat(this.pausedPayloads);
-    var commits = payloads.reduce(function (out, p) {
-        if (p.offset !== 0)
-            out.push(_.defaults({ offset: p.offset-1 }, p));
-        return out;
-    }, []);
 
+    var commits = payloads.filter(function (p) { return p.offset !== 0 });
     if (commits.length) {
         this.client.sendOffsetCommitRequest(this.options.groupId, commits, cb);
     } else {
@@ -211,10 +211,11 @@ Consumer.prototype.addTopics = function (topics, cb, fromOffset) {
             self.fetchOffset(payloads, function (err, offsets) {
                 if (err) return cb(err);
                 payloads.forEach(function (p) {
-                    p.offset = offsets[p.topic][p.partition];
+                    var offset = offsets[p.topic][p.partition];
+                    if (offset === -1) offset = 0;
+                    p.offset = offset;
                     self.payloads.push(p);
                 });
-                self.updateOffsets(offsets);
                 if (reFetch) self.fetch();
                 cb && cb(null, added);
             });

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -427,10 +427,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
 HighLevelConsumer.prototype.init = function () {
 
-    var self = this
-        , topics = self.topicPayloads.map(function (p) {
-            return p.topic;
-        })
+    var self = this;
 
     if (!self.topicPayloads.length) {
         return;
@@ -454,8 +451,12 @@ HighLevelConsumer.prototype.init = function () {
  */
 HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
     this.topicPayloads.forEach(function (p) {
-        if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined)
-            p.offset = topics[p.topic][p.partition] + 1;
+        if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined) {
+            var offset = topics[p.topic][p.partition];
+            if (offset === -1) offset = 0;
+            if (!initing) p.offset = offset + 1;
+            else p.offset = offset;
+        }
     });
 
     if (this.options.autoCommit && !initing) this.autoCommit();
@@ -469,11 +470,7 @@ function autoCommit(force, cb) {
         this.committing = false;
     }.bind(this), this.options.autoCommitIntervalMs);
 
-    var commits = this.topicPayloads.reduce(function (out, p) {
-        if (p.offset !== 0)
-            out.push(_.defaults({ offset: p.offset - 1 }, p));
-        return out;
-    }, []);
+    var commits = this.topicPayloads.filter(function (p) { return p.offset !== 0 });
 
     if (commits.length) {
         this.client.sendOffsetCommitRequest(this.options.groupId, commits, cb);
@@ -534,9 +531,12 @@ HighLevelConsumer.prototype.addTopics = function (topics, cb) {
             self.fetchOffset(payloads, function (err, offsets) {
                 if (err) return cb(err);
                 payloads.forEach(function (p) {
-                    p.offset = offsets[p.topic][p.partition];
+                    var offset = offsets[p.topic][p.partition];
+                    if (offset === -1) offset = 0;
+                    p.offset = offset;
                     self.topicPayloads.push(p);
                 });
+                // TODO: rebalance consumer
                 cb && cb(null, added);
             });
         }

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -254,9 +254,9 @@ Zookeeper.prototype.listConsumers = function (groupId) {
         },
         function (error, children) {
             if (error)
-                that.emit('error', error)
+                debug(error);
             else
-                that.emit('consumersChanged')
+                that.emit('consumersChanged');
         }
     );
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafka-node",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "main": "kafka.js",
   "dependencies": {
     "async": "0.7.0",

--- a/test/test.consumer.js
+++ b/test/test.consumer.js
@@ -344,6 +344,7 @@ describe('Consumer', function () {
                 {topic: EXISTS_TOPIC_2, partition: 1}
             ];
             var consumer = new Consumer(client, topics, {});
+            consumer.on('error', function () {});
 
             function normalize (p) {
                 return { topic: p.topic, partition: p.partition };
@@ -367,7 +368,7 @@ describe('Consumer', function () {
                 {topic: EXISTS_TOPIC_1, partition: 1},
                 {topic: EXISTS_TOPIC_2, partition: 0}
             ]);
-            
+
             consumer.resumeTopics([EXISTS_TOPIC_1, EXISTS_TOPIC_2]);
             consumer.payloads.sort(compare).should.eql(topics);
             consumer.pausedPayloads.should.eql([]);


### PR DESCRIPTION
We should ignore it when get null from queue, this may happen when a broker is down and it's callback queue is cleared, but there is some buffer still parsing. related issue #156 