### PR TITLE
Add a dockerized kafka for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 ALL_TESTS = $(shell find test -name 'test.*.js')
+KAFKA_TEST_HOST?=127.0.0.1
+
+kafka-instance:
+	# Always start tests with a clean slate by removing old instances
+	fig rm --force kafka zookeeper
+	KAFKA_ADVERTISED_HOST_NAME=$(KAFKA_TEST_HOST) fig up
+
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha $(ALL_TESTS)
 

--- a/README.md
+++ b/README.md
@@ -558,6 +558,12 @@ var kafka = require('kafka-node'),
 # Todo
 * Compression: gzip & snappy (√)
 
+# Development
+
+To run tests, run `make kafka-instance` in one terminal and then `make test` in another. You will need [docker](https://www.docker.com/) and [fig](http://www.fig.sh/) to be installed.
+
+If you are on a mac, you'll want to override the `KAFKA_TEST_HOST` environment variable to point to your [boot2docker](http://boot2docker.io/) instance. The commands would look like `KAFKA_TEST_HOST=$(boot2docker ip) make kafka-instance` and `KAFKA_TEST_HOST=$(boot2docker ip) make test` instead.
+
 # LICENSE - "MIT"
 Copyright (c) 2013 Sohu.com
 

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,16 @@
+zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+
+kafka:
+  image: wurstmeister/kafka:0.8.2.0
+  ports:
+    - "9092:9092"
+  links: 
+    - zookeeper:zk
+  environment:
+    KAFKA_ADVERTISED_HOST_NAME:
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+


### PR DESCRIPTION
It was not obvious how to run tests before this. This patch adds a
simple docker setup so you can run tests without manually setting up
kafka.

Currently some of the zookeeper tests fail, but putting the pull request forward to see if the maintainers would be amenable to this change.