### PR TITLE
Support sending a Message struct from the producer

### DIFF
--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -79,6 +79,9 @@ HighLevelProducer.prototype.buildPayloads = function (payloads) {
         p.attributes = p.attributes || 0;
         var messages = _.isArray(p.messages) ? p.messages : [p.messages];
         messages = messages.map(function (message) {
+            if (message instanceof Message) {
+                return message;
+            }
             return new Message(0, 0, '', message);
         });
         return new ProduceRequest(p.topic, p.partition, messages, p.attributes);

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -83,6 +83,9 @@ Producer.prototype.buildPayloads = function (payloads) {
         p.attributes = p.attributes || 0;
         var messages = _.isArray(p.messages) ? p.messages : [p.messages];
         messages = messages.map(function (message) {
+            if (message instanceof Message) {
+                return message;
+            }
             return new Message(0, 0, '', message);
         });
         return new ProduceRequest(p.topic, p.partition, messages, p.attributes);

--- a/test/test.producer.js
+++ b/test/test.producer.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var Producer = require('../lib/producer'),
-    Client = require('../lib/client');
+    Client = require('../lib/client'),
+    protocol = require('../lib/protocol/'),
+    Message = protocol.Message;
 
 var client, producer;
 
@@ -47,6 +49,15 @@ describe('Producer', function () {
 
         it('should send buffer message successfully', function (done) {
             var message = new Buffer('hello kafka');
+            producer.send([{ topic: EXISTS_TOPIC_3, messages: message }], function (err, message) {
+                message.should.be.ok;
+                message[EXISTS_TOPIC_3]['0'].should.be.above(0);
+                done(err);
+            });
+        });
+
+        it('should send Message struct successfully', function(done) {
+            var message = new Message(0, 0, 'test-key', 'test-message');
             producer.send([{ topic: EXISTS_TOPIC_3, messages: message }], function (err, message) {
                 message.should.be.ok;
                 message[EXISTS_TOPIC_3]['0'].should.be.above(0);


### PR DESCRIPTION
Currently the API does not offer a way to set the key on an outgoing
message. This resolves that hole by allowing devs to pass in Message
structs directly and have them be sent to the broker.

Has a test that passes.