### PR TITLE
Allow null message values

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -366,9 +366,14 @@ function encodeMessage(message) {
         .Int8(message.magic)
         .Int8(message.attributes)
         .Int32BE(message.key.length)
-        .string(message.key)
-        .Int32BE(Buffer.isBuffer(message.value) ? message.value.length : Buffer.byteLength(message.value))
-        .string(message.value).make();
+        .string(message.key);
+    if (message.value !== null) {
+        m = m.Int32BE(Buffer.isBuffer(message.value) ? message.value.length : Buffer.byteLength(message.value))
+        .string(message.value);
+    } else {
+        m = m.Int32BE(-1);
+    }
+    m = m.make();
     var crc = crc32.signed(m);
     return new Buffermaker()
         .Int32BE(crc)


### PR DESCRIPTION
Message values may be null. If we get a null, pass -1 for the length.