### PR TITLE
Support more message type

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,12 +114,12 @@ Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs
             var encoding = consumer.options.encoding;
 
             if (type === 'message') {
-              if (encoding !== 'buffer') {
-                message.value = message.value.toString(encoding);
-              }
-              consumer.emit('message', message);
+                if (encoding !== 'buffer' && message.value) {
+                    message.value = message.value.toString(encoding);
+                }
+                consumer.emit('message', message);
             } else {
-              consumer.emit('done', message);
+                consumer.emit('done', message);
             }
         }, maxTickMessages);
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -149,6 +149,8 @@ function decodeMessageSet(topic, partition, messageSet, cb, maxTickMessages) {
                 if (vars.value !== -1) {
                     cur += vars.value;
                     this.buffer('value', vars.value);
+                } else {
+                    vars.value = null;
                 }
 
                 if (!vars.partial && vars.offset !== null) {
@@ -367,11 +369,18 @@ function encodeMessage(message) {
         .Int8(message.attributes)
         .Int32BE(message.key.length)
         .string(message.key);
-    if (message.value !== null) {
-        m = m.Int32BE(Buffer.isBuffer(message.value) ? message.value.length : Buffer.byteLength(message.value))
-        .string(message.value);
+    var value = message.value;
+
+    if (value !== null) {
+        if (Buffer.isBuffer(value)) {
+            m.Int32BE(value.length);
+        } else {
+            if (typeof value !== 'string') value = value.toString();
+            m.Int32BE(Buffer.byteLength(value));
+        }
+        m.string(value);
     } else {
-        m = m.Int32BE(-1);
+        m.Int32BE(-1);
     }
     m = m.make();
     var crc = crc32.signed(m);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kafka-node",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "main": "kafka.js",
   "dependencies": {
     "async": "0.7.0",

--- a/test/test.producer.js
+++ b/test/test.producer.js
@@ -56,6 +56,24 @@ describe('Producer', function () {
             });
         });
 
+        it('should send null message successfully', function (done) {
+            var message = null;
+            producer.send([{ topic: EXISTS_TOPIC_3, messages: message }], function (err, message) {
+                message.should.be.ok;
+                message[EXISTS_TOPIC_3]['0'].should.be.above(0);
+                done(err);
+            });
+        });
+
+        it('should convert none buffer message to string', function (done) {
+            var message = -1;
+            producer.send([{ topic: EXISTS_TOPIC_3, messages: message }], function (err, message) {
+                message.should.be.ok;
+                message[EXISTS_TOPIC_3]['0'].should.be.above(0);
+                done(err);
+            });
+        })
+
         it('should send Message struct successfully', function(done) {
             var message = new KeyedMessage('test-key', 'test-message');
             producer.send([{ topic: EXISTS_TOPIC_3, messages: message }], function (err, message) {


### PR DESCRIPTION
If a message is not a buffer or string, then convert it to string with
`toString()`