### PR TITLE
Initialize partition owner with consumerId

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -326,7 +326,7 @@ Zookeeper.prototype.addPartitionOwnership = function (consumerId, groupId, topic
             function (callback) {
                 self.client.create(
                     path,
-                    null,
+                    new Buffer(consumerId),
                     null,
                     zookeeper.CreateMode.EPHEMERAL,
                     function (error, path) {
@@ -334,16 +334,6 @@ Zookeeper.prototype.addPartitionOwnership = function (consumerId, groupId, topic
                             callback(error);
                         else callback();
                     });
-            },
-            function (callback) {
-                self.client.setData(path, new Buffer(consumerId), function (error, stat) {
-                    if (error) {
-                        callback(error);
-                    }
-                    else {
-                        callback();
-                    }
-                });
             },
             function (callback) {
                 self.client.exists(path, null, function (error, stat) {


### PR DESCRIPTION
This avoids a race condition in `checkPartitionOwnership`, where another instance may create the node initialized to `null`, so the node will exist, it will try to get its contents but will fail in the comparison `consumerId !== data.toString()` since data may be `null`.