### PR TITLE
Small performance improvement in topics diff

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -241,9 +241,8 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
         if (isAsync) return cb(null, 'All requests sent');
         var topicMetadata = resp[1].metadata;
         // ommit existed topics
-        var existed = Object.keys(topicMetadata);
         var topicsNotExists = topics.filter(function (topic) {
-            return !~existed.indexOf(topic);
+            return !(topic in topicMetadata);
         });
 
         function attemptCreateTopics (topics, cb) {


### PR DESCRIPTION
This pull requests slightly improves the performance of diff-ing the already created topics `topicMetadata`, with the list of topics that the user want's to create `topics`.

On average `a in b` should be faster than `b.indexOf(a)`.
