### PR TITLE
fix: emit the error instead of slient swallow it

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -253,10 +253,12 @@ Zookeeper.prototype.listConsumers = function (groupId) {
             that.listConsumers(groupId);
         },
         function (error, children) {
-            if (error)
+            if (error) {
                 debug(error);
-            else
+                that.emit('error', error);
+            } else {
                 that.emit('consumersChanged');
+            }
         }
     );
 };


### PR DESCRIPTION
I got kafka-node:zookeeper Exception: CONNECTION_LOSS[-4] error
sometimes, and the error sliently swallowed so it can not be catched

I thought the error should be thrown instead of been sliently swallowed.