### PR TITLE
Fix: add callback to consumer.autoCommit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # kafka-node CHANGELOG
 
+## 2015-04-23, Version 0.2.26
+- Fix: add callback to consumer.autoCommit method [#198](https://github.com/SOHU-Co/kafka-node/pull/198)
+- Emit an error when there is a problem with the socket connection to the kafka broker [#196](https://github.com/SOHU-Co/kafka-node/pull/196)
+- Fix: emit the error instead of slient swallow it [#193](https://github.com/SOHU-Co/kafka-node/pull/193)
+- Typo in error message [#189](https://github.com/SOHU-Co/kafka-node/pull/189)
+
 ## 2015-04-01, Version 0.2.25
 - Producer support `requireAcks` option [#187](https://github.com/SOHU-Co/kafka-node/pull/187)
 - Update examples [#185](https://github.com/SOHU-Co/kafka-node/pull/185)

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -141,11 +141,15 @@ Consumer.prototype.updateOffsets = function (topics, initing) {
         }
     });
 
-    if (this.options.autoCommit && !initing) this.autoCommit();
+    if (this.options.autoCommit && !initing) {
+        this.autoCommit(false, function (err) {
+            err && debug('auto commit offset', err);
+        });
+    }
 };
 
 function autoCommit(force, cb) {
-    if (this.committing && !force) return cb && cb('Offset committing');
+    if (this.committing && !force) return cb(null, 'Offset committing');
 
     this.committing = true;
     setTimeout(function () {
@@ -159,7 +163,7 @@ function autoCommit(force, cb) {
     if (commits.length) {
         this.client.sendOffsetCommitRequest(this.options.groupId, commits, cb);
     } else {
-        cb && cb();
+        cb(null, 'Nothing to be committed');
     }
 }
 Consumer.prototype.commit = Consumer.prototype.autoCommit = autoCommit;

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -452,11 +452,15 @@ HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
         }
     });
 
-    if (this.options.autoCommit && !initing) this.autoCommit();
+    if (this.options.autoCommit && !initing) {
+        this.autoCommit(false, function (err) {
+            err && debug('auto commit offset', err);
+        });
+    }
 };
 
 function autoCommit(force, cb) {
-    if (this.committing && !force) return cb && cb('Offset committing');
+    if (this.committing && !force) return cb(null, 'Offset committing');
 
     this.committing = true;
     setTimeout(function () {
@@ -468,7 +472,7 @@ function autoCommit(force, cb) {
     if (commits.length) {
         this.client.sendOffsetCommitRequest(this.options.groupId, commits, cb);
     } else {
-        cb && cb();
+        cb(null, 'Nothing to be committed');
     }
 }
 HighLevelConsumer.prototype.commit = HighLevelConsumer.prototype.autoCommit = autoCommit;


### PR DESCRIPTION
Add callback function to consumer.autoCommit to prevent program from
crashing when broker is not available.