### PR TITLE
Add autoCommit default value to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ consumer.close(cb); //force is disabled
 {
     groupId: 'kafka-node-group',//consumer group id, deafult `kafka-node-group`
     // Auto commit config
+    autoCommit: true,
     autoCommitIntervalMs: 5000,
     // The max wait time is the maximum amount of time in milliseconds to block waiting if insufficient data is available at the time the request is issued, default 100ms
     fetchMaxWaitMs: 100,


### PR DESCRIPTION
Add default autoCommit to HighLevelConsumer documentation so people know that they can set it to something else.