### PR TITLE
Exit cleanly from HighLevelConsumer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,7 +86,7 @@ Client.prototype.connect = function () {
 Client.prototype.close = function (cb) {
     this.closeBrokers(this.brokers);
     this.closeBrokers(this.longpollingBrokers);
-    this.zk.client.close();
+    this.zk.close();
     cb && cb();
 };
 

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -250,7 +250,9 @@ Zookeeper.prototype.listConsumers = function (groupId) {
     this.client.getChildren(
         path,
         function () {
-            that.listConsumers(groupId);
+            if (!that.closed) {
+                that.listConsumers(groupId);
+            }
         },
         function (error, children) {
             if (error) {
@@ -396,6 +398,11 @@ Zookeeper.prototype.checkPartitionOwnership = function (consumerId, groupId, top
             if (err) cb(err);
             else cb();
         });
+};
+
+Zookeeper.prototype.close = function () {
+    this.closed = true;
+    this.client.close();
 };
 
 var ZookeeperConsumerMappings = function () {


### PR DESCRIPTION
When using the `HighLevelConsumer`, the `ZooKeeper` client continues to recursively run `listConsumers` even after closing.

This causes an exception to be thrown if the process does not exit immediately.