### PR TITLE
Update snappy dependency to ^3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node-uuid": "~1.4.3",
     "node-zookeeper-client": "~0.2.2",
     "retry": "~0.6.1",
-    "snappy": "~3.0.8"
+    "snappy": "^3.2.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1",


### PR DESCRIPTION
- Fixes installation problem when using iojs 2 (due to nan dependency in snappy
  3.0.8).
- This is a proposed fix to issue: https://github.com/SOHU-Co/kafka-node/issues/204