### PR TITLE
Do not update offsets when fetch request complete when autoCommit is set to false

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -235,7 +235,9 @@ HighLevelConsumer.prototype.connect = function () {
 
     // 'done' will be emit when a message fetch request complete
     this.on('done', function (topics) {
-        self.updateOffsets(topics);
+        if(this.options.autoCommit){
+            self.updateOffsets(topics);
+        }
         if (!self.paused) {
             setImmediate(function () {
                 self.fetch();


### PR DESCRIPTION
In my project I use my own offset commit strategy and `autoCommit` is set to false. I maintain offset map in memory and update/commit offsets only when messages is processed, not when fetched.
Currently offsets are updated when every time when fetch request is completed. 

This PR checks if `autoCommit` is disabled and do not update offsets in this case. 

Thank you for your time.
