### PR TITLE
fix(HighLevelProducer): allow sending to partition 0

### DIFF
--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -83,7 +83,7 @@ HighLevelProducer.prototype.send = function (payloads, cb) {
 HighLevelProducer.prototype.buildPayloads = function (payloads) {
     var self = this;
     return payloads.map(function (p) {
-        p.partition = p.partition || self.client.nextPartition(p.topic);
+        p.partition = p.hasOwnProperty('partition') ? p.partition : self.client.nextPartition(p.topic);
         p.attributes = p.attributes || 0;
         var messages = _.isArray(p.messages) ? p.messages : [p.messages];
         messages = messages.map(function (message) {


### PR DESCRIPTION
```js
p.partition = p.partition || self.client.nextPartition(p.topic);
```
will override p.partition with nextPartition() for a value of 0 because 0 is falsy.

This fixes it.