### PR TITLE
HighLevelProducer does not allow setting partition to 0

### DIFF
--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -83,7 +83,7 @@ HighLevelProducer.prototype.send = function (payloads, cb) {
 HighLevelProducer.prototype.buildPayloads = function (payloads) {
     var self = this;
     return payloads.map(function (p) {
-        p.partition = p.partition || self.client.nextPartition(p.topic);
+        p.partition = p.hasOwnProperty('partition') ? p.partition : self.client.nextPartition(p.topic);
         p.attributes = p.attributes || 0;
         var messages = _.isArray(p.messages) ? p.messages : [p.messages];
         messages = messages.map(function (message) {


### PR DESCRIPTION
If you send payloads with partition set to 0 using the HighLevelProducer, the partition number is ignored, and it just uses the next partition from `client.nextPartition()`.

This is the use case:
```javascript
var client = new kafka.Client(/* ... */);
var producer = new kafka.HighLevelProducer(client);



// Once clients are connected...



var payloads = [
    {
        topic: 'test',
        messages: [ 'message one' ],
        partition: 0
    },
    {
        topic: 'test',
        messages: [ 'message two' ],
        partition: 0
    }
];

producer.send(payloads[0], function (err, res) {
    // Gets sent to partition 0

    producer.send(payloads[1], function (err, res) {
        // Gets sent to partition 1

    });
});
```