### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node-uuid": "~1.4.3",
     "node-zookeeper-client": "~0.2.2",
     "retry": "~0.6.1",
-    "snappy": "^4.0.0"
+    "snappy": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^2.2.1",


### PR DESCRIPTION
My testing looks to show that an upgrade to snappy@4.0.1 works with kafka-node on NodeJs version 4.x - reference this issue I created
 
https://github.com/SOHU-Co/kafka-node/issues/253
