### PR TITLE
Hold messages in memory buffer while broker unavailable

### DIFF
--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -1,8 +1,10 @@
 'use strict';
 
 var util = require('util'),
+    debug = require('debug')('kafka-node:HighLevelProducer'),
     events = require('events'),
     _ = require('lodash'),
+    async = require('async'),
     Client = require('./client'),
     protocol = require('./protocol'),
     Message = protocol.Message,
@@ -41,6 +43,10 @@ var HighLevelProducer = function (client, options) {
         ? DEFAULTS.ackTimeoutMs
         : options.ackTimeoutMs;
 
+    this.buffer = [];
+    this.bufferLimit = options.bufferLimit || 0;
+    this.buffering = false;
+
     this.connect();
 };
 
@@ -58,13 +64,61 @@ HighLevelProducer.prototype.connect = function () {
         }
     });
     this.client.on('brokersChanged', function () {
-        this.topicMetadata = {}
+        this.topicMetadata = {};
+        self.flushBuffer();
     });
     this.client.on('error', function (err) {
-        self.emit('error', err);
+        var isConnectionError = err.code === 'EPIPE' || err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED';
+        var isBrokerNotAvailable = err.message === 'NotLeaderForPartition' || err.name === 'BrokerNotAvailableError'
+        if (self.bufferLimit > 0 && (isConnectionError || isBrokerNotAvailable)) {
+            self.buffering = true;
+            debug(err); // all good here! producer will buffer ...
+        } else {
+            self.emit('error', err);
+        }
     });
     this.client.on('close', function () {
     });
+};
+
+/**
+ * Adds a message to the buffer for retrying when broker becomes available.
+ */
+HighLevelProducer.prototype.appendToBuffer = function (message) {
+    this.buffering = true;
+    this.buffer.push(message);
+};
+
+/**
+ * Send all messages held in the memory buffer while the broker has been unavailable.
+ */
+HighLevelProducer.prototype.flushBuffer = function () {
+    var self = this;
+    var error = null;
+    async.whilst(
+        function () {
+            return !error && self.buffer.length > 0;
+        },
+        function (cb) {
+            var message = self.buffer.shift();
+            self.buffering = false;
+            self.send(message.payloads, function (err, response) {
+                if (err) {
+                    return cb(err);
+                }
+                message.cb(null, response);
+                cb();
+            });
+        },
+        function (err) {
+            if (err) {
+                error = err;
+                debug('failed to flush buffer', err);
+                return;
+            }
+            debug('buffer has been successfully flushed');
+        }
+    );
 };
 
 /**
@@ -77,7 +131,23 @@ HighLevelProducer.prototype.connect = function () {
  * @param {HighLevelProducer~sendCallback} cb A function to call once the send has completed
  */
 HighLevelProducer.prototype.send = function (payloads, cb) {
-    this.client.sendProduceRequest(this.buildPayloads(payloads), this.requireAcks, this.ackTimeoutMs, cb);
+    var self = this,
+        client = this.client,
+        requireAcks = this.requireAcks,
+        ackTimeoutMs = this.ackTimeoutMs;
+
+    client.sendProduceRequest(this.buildPayloads(payloads), requireAcks, ackTimeoutMs, function producerSend(err, res) {
+        if (err) {
+            var isBrokerNotAvailable = err.message === 'NotLeaderForPartition' || err.name === 'BrokerNotAvailableError';
+            if ((self.buffering || isBrokerNotAvailable) && self.bufferLimit > self.buffer.length) {
+                self.appendToBuffer({payloads: payloads, cb: cb});
+            } else {
+                cb(err);
+            }
+        } else {
+            cb(null, res);
+        }
+    });
 };
 
 HighLevelProducer.prototype.buildPayloads = function (payloads) {

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('util'),
+    debug = require('debug')('kafka-node:Producer'),
     events = require('events'),
     _ = require('lodash'),
     async = require('async'),
@@ -42,6 +43,10 @@ var Producer = function (client, options) {
         ? DEFAULTS.ackTimeoutMs
         : options.ackTimeoutMs;
 
+    this.buffer = [];
+    this.bufferLimit = options.bufferLimit || 0;
+    this.buffering = false;
+
     this.connect();
 };
 
@@ -59,13 +64,61 @@ Producer.prototype.connect = function () {
         }
     });
     this.client.on('brokersChanged', function () {
-        this.topicMetadata = {}
+        this.topicMetadata = {};
+        self.flushBuffer();
     });
     this.client.on('error', function (err) {
-        self.emit('error', err);
+        var isConnectionError = err.code === 'EPIPE' || err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED';
+        var isBrokerNotAvailable = err.message === 'NotLeaderForPartition' || err.name === 'BrokerNotAvailableError'
+        if (self.bufferLimit > 0 && (isConnectionError || isBrokerNotAvailable)) {
+            self.buffering = true;
+            debug(err); // all good here! producer will buffer ...
+        } else {
+            self.emit('error', err);
+        }
     });
     this.client.on('close', function () {
     });
+};
+
+/**
+ * Adds a message to the buffer for retrying when broker becomes available.
+ */
+Producer.prototype.appendToBuffer = function (message) {
+    this.buffering = true;
+    this.buffer.push(message);
+};
+
+/**
+ * Send all messages held in the memory buffer while the broker has been unavailable.
+ */
+Producer.prototype.flushBuffer = function () {
+    var self = this;
+    var error = null;
+    async.whilst(
+        function () {
+            return !error && self.buffer.length > 0;
+        },
+        function (cb) {
+            var message = self.buffer.shift();
+            self.buffering = false;
+            self.send(message.payloads, function (err, response) {
+                if (err) {
+                    return cb(err);
+                }
+                message.cb(null, response);
+                cb();
+            });
+        },
+        function (err) {
+            if (err) {
+                error = err;
+                debug('failed to flush buffer', err);
+                return;
+            }
+            debug('buffer has been successfully flushed');
+        }
+    );
 };
 
 /**
@@ -78,11 +131,23 @@ Producer.prototype.connect = function () {
  * @param {Producer~sendCallback} cb A function to call once the send has completed
  */
 Producer.prototype.send = function (payloads, cb) {
-    var client = this.client,
+    var self = this,
+        client = this.client,
         requireAcks = this.requireAcks,
         ackTimeoutMs = this.ackTimeoutMs;
 
-    client.sendProduceRequest(this.buildPayloads(payloads), requireAcks, ackTimeoutMs, cb);
+    client.sendProduceRequest(this.buildPayloads(payloads), requireAcks, ackTimeoutMs, function producerSend(err, res) {
+        if (err) {
+            var isBrokerNotAvailable = err.message === 'NotLeaderForPartition' || err.name === 'BrokerNotAvailableError';
+            if ((self.buffering || isBrokerNotAvailable) && self.bufferLimit > self.buffer.length) {
+                self.appendToBuffer({payloads: payloads, cb: cb});
+            } else {
+                cb(err);
+            }
+        } else {
+            cb(null, res);
+        }
+    });
 };
 
 Producer.prototype.buildPayloads = function (payloads) {


### PR DESCRIPTION
This will allow doing maintenance tasks in a Kafka cluster, when brokers need to be taken down for various reason, without having the producers throwing errors and having to handle this logic in the app, or let the app crash to restart and find the new leader.

The pull request has room for improvement:
1) I originally added this logic to the Kafka client, but then I didn't want to add an extra argument to the constructor, since these new options don't belong to the zookeeper options that is currently passed.
2) If logic added to the consumers, I would have preferred to not duplicate logic, but I didn't find a simple way without doing too much refactor of both consumers to reduce duplication. In fact, they already suffer this problem.
3) I'm not 100% confident I'm handling errors correctly, so I'd appreciate feedback here. I've left one scenario unhandled, that is when the 1st argument is not an error object but an array with an string such us [ 'LeaderNotAvailable' ] or [ 'Unknown' ]. It's a best practice to return Error objects, and it would be a better idea to fix that instead.

Let me know what you think of this and I can update the pull request if needed.