### PR TITLE
encode -1 when key is empty or is null

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -366,9 +366,16 @@ function encodeMessageSet(messageSet) {
 function encodeMessage(message) {
     var m = new Buffermaker()
         .Int8(message.magic)
-        .Int8(message.attributes)
-        .Int32BE(message.key.length)
-        .string(message.key);
+        .Int8(message.attributes);
+
+    var key = message.key;
+    if (key) {
+        m.Int32BE(message.key.length);
+        m.string(message.key);
+    } else {
+        m.Int32BE(-1);
+    }
+
     var value = message.value;
 
     if (value !== null) {


### PR DESCRIPTION
Allow for null keys.  We ran into issues running mirrormaker where the keyedmessages on the source broker had blank strings for the key instead of null.  This caused all the messages to be hashed to the same partition when mirrormaker republished.