### PR TITLE
Replace node-uuid with a pure-JS implementation

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -5,7 +5,7 @@ var util = require('util'),
     events = require('events'),
     Client = require('./client'),
     protocol = require('./protocol'),
-    uuid = require('node-uuid'),
+    uuid = require('cassandra-uuid').Uuid,
     Offset = require('./offset'),
     async = require("async"),
     errors = require('./errors'),
@@ -48,7 +48,7 @@ var HighLevelConsumer = function (client, topics, options) {
     this.ready = false;
     this.paused = this.options.paused;
     this.rebalancing = false;
-    this.id = this.options.groupId + '_' + uuid.v4();
+    this.id = this.options.groupId + '_' + uuid.random();
     this.payloads = this.buildPayloads(topics);
     this.topicPayloads = this.buildTopicPayloads(topics);
     this.connect();

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "binary": "~0.3.0",
     "buffer-crc32": "~0.2.5",
     "buffermaker": "~1.2.0",
+    "cassandra-uuid": "^0.0.2",
     "debug": "^2.1.3",
     "lodash": ">3.0 <4.0",
-    "node-uuid": "~1.4.3",
     "node-zookeeper-client": "~0.2.2",
     "retry": "~0.6.1",
     "snappy": "^4.0.1"


### PR DESCRIPTION
The Apache Cassandra [driver](https://github.com/datastax/nodejs-driver) contains pure-JS UUID v1/v4 generators, which have been extracted into a separate repository - [`cassandra-uuid`](https://github.com/Pchelolo/uuid). Since the generation is used only in the HighLevelConsumer class, replace the binary module dependency with a pure one.
