### PR TITLE
add in the ability to supply our own id for the consumer

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -48,7 +48,7 @@ var HighLevelConsumer = function (client, topics, options) {
     this.ready = false;
     this.paused = this.options.paused;
     this.rebalancing = false;
-    this.id = this.options.groupId + '_' + uuid.v4();
+    this.id = this.options.id || this.options.groupId + '_' + uuid.v4();
     this.payloads = this.buildPayloads(topics);
     this.topicPayloads = this.buildTopicPayloads(topics);
     this.connect();

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -250,6 +250,16 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     var consumerPerTopicMap;
     var newTopicPayloads = [];
     debug("HighLevelConsumer %s is attempting to rebalance", self.id);
+
+    if (this.rebalancing) {
+        debug("rebalance already in progress, abort second rebalance", self.id);
+        if (!!cb) {
+            return cb();
+        }
+
+        return;
+    }
+
     async.series([
 
             // Stop fetching data and commit offsets

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -251,15 +251,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     var newTopicPayloads = [];
     debug("HighLevelConsumer %s is attempting to rebalance", self.id);
 
-    if (this.rebalancing) {
-        debug("rebalance already in progress, abort second rebalance", self.id);
-        if (!!cb) {
-            return cb();
-        }
-
-        return;
-    }
-
     async.series([
 
             // Stop fetching data and commit offsets

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -134,7 +134,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
                                             cbb();
                                         } catch (e) {
                                             debug(e);
-                                            callback(new Error("Unable to assemble data"));
+                                            cbb(new Error("Unable to assemble data"));
                                         }
                                     }
                                 }


### PR DESCRIPTION
Just a small change, this gives the ability to use a predefined consumer id if you want. 
Makes it easier to make a restful proxy, like if you are replacing the confluentinc one :)