### PR TITLE
Add support for autoOffsetReset in high level consumer and default to largest

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -14,6 +14,8 @@ var util = require('util'),
     retry = require('retry'),
     debug = require('debug')('kafka-node:HighLevelConsumer');
 
+var AUTOOFFSETRESET_LARGEST = 'largest';
+
 var DEFAULTS = {
     groupId: 'kafka-node-group',
     // Auto commit config
@@ -27,7 +29,8 @@ var DEFAULTS = {
     fetchMinBytes: 1,
     fetchMaxBytes: 1024 * 1024,
     maxTickMessages: 1000,
-    fromOffset: false
+    fromOffset: false,
+    autoOffsetReset: AUTOOFFSETRESET_LARGEST
 };
 
 var nextId = (function () {
@@ -443,10 +446,11 @@ HighLevelConsumer.prototype.init = function () {
  * @param {Boolean} Don't commit when initing consumer
  */
 HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
+    var reset = this.options.autoOffsetReset === AUTOOFFSETRESET_LARGEST;
     this.topicPayloads.forEach(function (p) {
         if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined) {
             var offset = topics[p.topic][p.partition];
-            if (offset === -1) offset = 0;
+            if (!reset && offset === -1) p.offset = 0;
             if (!initing) p.offset = offset + 1;
             else p.offset = offset;
         }
@@ -486,7 +490,33 @@ HighLevelConsumer.prototype.fetch = function () {
 };
 
 HighLevelConsumer.prototype.fetchOffset = function (payloads, cb) {
-    this.client.sendOffsetFetchRequest(this.options.groupId, payloads, cb);
+    var self = this;
+    this.client.sendOffsetFetchRequest(this.options.groupId, payloads, function (e, offsetFetchResponse) {
+
+        if (self.options.autoOffsetReset != AUTOOFFSETRESET_LARGEST) return cb(e, offsetFetchResponse);
+
+        var latest = [];
+        for (var topicName in offsetFetchResponse) {
+            var topic = offsetFetchResponse[topicName];
+            for (var partition in topic) {
+                if (topic[partition] === -1) {
+                    latest.push({ topic: topicName, partition: partition, time: -1, maxNum: 1, metadata: 'm' });
+                }
+            }
+        }
+
+        if (!latest.length) return cb(e, offsetFetchResponse);
+
+        self.client.sendOffsetRequest(latest, function (e, offsetResponse) {
+            for (var topicName in offsetResponse) {
+                var topic = offsetResponse[topicName];
+                for (var partition in topic) {
+                    offsetFetchResponse[topicName][partition] = topic[partition][0];
+                }
+            }
+            cb(e, offsetFetchResponse);
+        });
+    });
 };
 
 HighLevelConsumer.prototype.offsetRequest = function (payloads, cb) {


### PR DESCRIPTION
Kafka's default offset for a consumer is the largest for the partition (https://kafka.apache.org/08/configuration.html). This change ensures that any new consumer with no initial offset in Zookeeper will reset to the largest offset by default.