### PR TITLE
Fix/duplicate callback issue #269

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -134,7 +134,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
                                             cbb();
                                         } catch (e) {
                                             debug(e);
-                                            callback(new Error("Unable to assemble data"));
+                                            cbb(new Error("Unable to assemble data"));
                                         }
                                     }
                                 }


### PR DESCRIPTION
fix for issue #269, rename the variable callback to cbb to stop the callback from failing.

to reproduce create multiple high level consumers very quickly, the error produced is 
```
/opt/kafka-http-proxy/node_modules/kafka-node/node_modules/async/lib/async.js:43
            if (fn === null) throw new Error("Callback was already called.");
                                   ^
Error: Callback was already called.
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/async/lib/async.js:43:36
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/async/lib/async.js:718:17
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/async/lib/async.js:167:37
    at /opt/kafka-http-proxy/node_modules/kafka-node/lib/zookeeper.js:137:45
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:165:26
    at Object.async.whilst (/opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/node_modules/async/lib/async.js:627:13)
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/node_modules/async/lib/async.js:623:23
    at /opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:145:21
    at Object.callback (/opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:582:17)
    at ConnectionManager.onSocketData (/opt/kafka-http-proxy/node_modules/kafka-node/node_modules/node-zookeeper-client/lib/ConnectionManager.js:562:35)
```