### PR TITLE
Use synchronous decompression

### DIFF
--- a/lib/codec/index.js
+++ b/lib/codec/index.js
@@ -5,7 +5,8 @@ var zlib = require('zlib'),
 
 var gzipCodec = {
     encode: zlib.gzip,
-    decode: zlib.gunzip
+    decode: zlib.gunzip,
+    decodeSync: zlib.gunzipSync
 };
 
 var codecs = [

--- a/lib/codec/snappy.js
+++ b/lib/codec/snappy.js
@@ -37,5 +37,31 @@ function decodeSnappy(buffer, cb) {
     return snappy.uncompress(buffer, cb);
 }
 
+function decodeSnappySync(buffer) {
+    if (isChunked(buffer)) {
+        var pos = 16,
+            max = buffer.length,
+            encoded = [],
+            size;
+
+        while (pos < max) {
+            size = buffer.readUInt32BE(pos);
+            pos += 4;
+            encoded.push(buffer.slice(pos, pos + size));
+            pos += size;
+        }
+
+        var decodedChunks = encoded.map(function(data) {
+            var ret = snappy.uncompressSync(data);
+            return ret;
+        });
+
+        return Buffer.concat(decodedChunks);
+    }
+    return snappy.uncompressSync(buffer);
+}
+
 exports.encode = snappy.compress;
 exports.decode = decodeSnappy;
+exports.decodeSync = decodeSnappySync;
+

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -167,10 +167,9 @@ function decodeMessageSet(topic, partition, messageSet, cb, maxTickMessages) {
                             key: vars.key
                         });
                     }
-                    codec.decode(vars.value, function(error, inlineMessageSet) {
-                        if (error) return; // Not sure where to report this
-                        decodeMessageSet(topic, partition, inlineMessageSet, cb, maxTickMessages);
-                    });
+
+                    var inlineMessageSet = codec.decodeSync(vars.value);
+                    decodeMessageSet(topic, partition, inlineMessageSet, cb, maxTickMessages);
                 }
             });
         // Defensive code around potential denial of service


### PR DESCRIPTION
This fixes #298 which was caused by asynchronous nested message set decompression which resulted in out of order message consuming. Kafka returns messages in MessageSet which contains nested compressed MessageSets of 2000 messages (in my testing). Unfortunately decompression was asynchronous without any synchronisation, so messages were processed out of order in batches of max 2000 (depends on maxTickMessages). My fix applies synchronous decompression.
