### PR TITLE
Increase default maxTickMessages

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -26,7 +26,7 @@ var DEFAULTS = {
     maxNumSegments: 1000,
     fetchMinBytes: 1,
     fetchMaxBytes: 1024 * 1024,
-    maxTickMessages: 1000,
+    maxTickMessages: 10000,
     fromOffset: false
 };
 


### PR DESCRIPTION
Kafka returns messages in MessageSet which contains nested compressed MessageSets of 2000 messages (in my testing). Default `maxTickMessages` of 1000 in HighLevelConsumer causes to drop one half of every nested MessageSet messages and also could drop nested MessageSets itself if there would be enough of them. Increasing `maxTickMessages` to 10000 should ensure messages are not dropped .