### PR TITLE
Make `commit()` handle case when only callback is passed

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -149,6 +149,11 @@ Consumer.prototype.updateOffsets = function (topics, initing) {
 };
 
 function autoCommit(force, cb) {
+    if (arguments.length === 1) {
+        cb = force;
+        force = false;
+    }
+
     if (this.committing && !force) return cb(null, 'Offset committing');
 
     this.committing = true;

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -476,6 +476,11 @@ HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
 };
 
 function autoCommit(force, cb) {
+    if (arguments.length === 1) {
+        cb = force;
+        force = false;
+    }
+
     if (this.committing && !force) return cb(null, 'Offset committing');
 
     this.committing = true;


### PR DESCRIPTION
Currently `commit()` method in consumer and high level consumer accepts two arguments. And it does not handle case with one argument, if I'm correct. This PR fixes the issue.

Fixes #296