### PR TITLE
Skip message before requested offset

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,7 @@ var net  = require('net'),
     getCodec = require('./codec'),
     protocol = require('./protocol'),
     encodeMessageSet = protocol.encodeMessageSet,
+    groupByTopicAndPartition = require('./utils.js').groupByTopicAndPartition,
     Message = protocol.Message,
     zk = require('./zookeeper'),
     Zookeeper = zk.Zookeeper,
@@ -105,6 +106,7 @@ Client.prototype.closeBrokers = function (brokers) {
 };
 
 Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs, fetchMinBytes, maxTickMessages) {
+    var groupedPayloads = groupByTopicAndPartition(payloads);
     var self = this;
     var encoder = protocol.encodeFetchRequest(fetchMaxWaitMs, fetchMinBytes);
     var decoder = protocol.decodeFetchResponse(function (err, type, message) {
@@ -121,11 +123,14 @@ Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs
             var encoding = consumer.options.encoding;
 
             if (type === 'message') {
-                if (encoding !== 'buffer' && message.value) {
-                    message.value = message.value.toString(encoding);
-                }
+                var skip = message.offset <= groupedPayloads[message.topic][message.partition].offset;
+                if (!skip) {
+                    if (encoding !== 'buffer' && message.value) {
+                        message.value = message.value.toString(encoding);
+                    }
 
-                consumer.emit('message', message);
+                    consumer.emit('message', message);
+                }
             } else {
                 consumer.emit('done', message);
             }

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -6,6 +6,7 @@ var Binary = require('binary'),
     crc32 = require('buffer-crc32'),
     protocol = require('./protocol_struct'),
     getCodec = require('../codec'),
+    groupByTopic = require('../utils.js').groupByTopicAndPartition,
     KEYS = protocol.KEYS,
     REQUEST_TYPE = protocol.REQUEST_TYPE,
     ERROR_CODE = protocol.ERROR_CODE,
@@ -17,14 +18,6 @@ var API_VERSION = 0,
     CODEC_NONE = 0,
     CODEC_GZIP = 1,
     CODEC_SNAPPY = 2;
-
-function groupByTopic(payloads) {
-    return payloads.reduce(function (out, p) {
-        out[p.topic] = out[p.topic] || {};
-        out[p.topic][p.partition] = p;
-        return out;
-    }, {});
-}
 
 function encodeRequestWithLength(request) {
     return new Buffermaker()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function groupByTopicAndPartition(payloads) {
+    return payloads.reduce(function (out, p) {
+        out[p.topic] = out[p.topic] || {};
+        out[p.topic][p.partition] = p;
+        return out;
+    }, {});
+}
+
+module.exports.groupByTopicAndPartition = groupByTopicAndPartition;


### PR DESCRIPTION
This change reflects original [consumer behaviour](https://github.com/apache/kafka/blob/b62f8ea43b6d5307f7274fbe8b7984dd5ee22239/core/src/main/scala/kafka/consumer/ConsumerIterator.scala#L96), which skips fetched messages with offset smaller than requested. Kafka may and does send older messages than requested. Works best with #301 and #302.