### PR TITLE
Fix for broker 'undefined' from brokerForLeader's BrokerNotAvailableError emit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -231,7 +231,7 @@ Client.prototype.loadMetadataForTopics = function (topics, cb) {
     var request = protocol.encodeMetadataRequest(this.clientId, correlationId, topics);
     var broker = this.brokerForLeader();
 
-    if (!broker.socket || broker.socket.error) {
+    if (!broker || !broker.socket || broker.socket.error) {
         return cb(new errors.BrokerNotAvailableError('Broker not available'));
     }
 


### PR DESCRIPTION
Fix for broker 'undefined' if Kafka server goes down and zookeeper is still up.

/home/vagrant/git/app/node_modules/kafka-node/lib/client.js:234
    if (!broker.socket || broker.socket.error) {
               ^
TypeError: Cannot read property 'socket' of undefined
    at Client.loadMetadataForTopics (/home/vagrant/git/app/node_modules/kafka-node/lib/client.js:234:16)
    at Client.send (/home/vagrant/git/app/node_modules/kafka-node/lib/client.js:384:14)
    at Client.sendOffsetCommitRequest (/home/vagrant/git/app/node_modules/kafka-node/lib/client.js:187:10)
    at autoCommit (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:489:21)
    at HighLevelConsumer.stop (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:588:10)
    at async.series.self.client.zk.getConsumersPerTopic.consumerPerTopicMap (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:274:22)
    at /home/vagrant/git/app/node_modules/kafka-node/node_modules/async/lib/async.js:718:13
    at iterate (/home/vagrant/git/app/node_modules/kafka-node/node_modules/async/lib/async.js:262:13)
    at async.forEachOfSeries.async.eachOfSeries (/home/vagrant/git/app/node_modules/kafka-node/node_modules/async/lib/async.js:281:9)
    at _parallel (/home/vagrant/git/app/node_modules/kafka-node/node_modules/async/lib/async.js:717:9)
    at Object.async.series (/home/vagrant/git/app/node_modules/kafka-node/node_modules/async/lib/async.js:739:9)
    at HighLevelConsumer.rebalanceAttempt (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:269:11)
    at RetryOperation._fn (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:161:22)
    at RetryOperation.attempt (/home/vagrant/git/app/node_modules/kafka-node/node_modules/retry/lib/retry_operation.js:56:8)
    at rebalance (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:160:23)
    at null.<anonymous> (/home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:190:9)
    at emit (events.js:92:17)
    at /home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:452:21
    at /home/vagrant/git/app/node_modules/kafka-node/lib/highLevelConsumer.js:523:9
    at /home/vagrant/git/app/node_modules/kafka-node/lib/zookeeper.js:85:25
    at /home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:165:26
    at Object.async.whilst (/home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/node_modules/async/lib/async.js:627:13)
    at /home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/node_modules/async/lib/async.js:623:23
    at /home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:145:21
    at Object.callback (/home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/index.js:525:17)
    at ConnectionManager.onSocketData (/home/vagrant/git/app/node_modules/kafka-node/node_modules/node-zookeeper-client/lib/ConnectionManager.js:562:35)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:426:10)
    at emitReadable (_stream_readable.js:422:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at Socket.Readable.push (_stream_readable.js:127:10)
    at TCP.onread (net.js:528:21)