### PR TITLE
Fix #273 by making snappy an optional dependency

### DIFF
--- a/lib/codec/snappy.js
+++ b/lib/codec/snappy.js
@@ -1,7 +1,19 @@
 'use strict';
 
-var async = require('async'),
-    snappy = require('snappy');
+var optional = require('optional'),
+    async = require('async'),
+    snappy = optional('snappy');
+
+if (snappy == null) {
+    var unavailableCodec = function unavailableCodec() {
+        throw new Error('Snappy codec is not installed');
+    }
+    module.exports = {
+        encode : unavailableCodec,
+        decode : unavailableCodec
+    };
+    return;
+}
 
 var SNAPPY_MAGIC_BYTES = [130, 83, 78, 65, 80, 80, 89, 0],
     SNAPPY_MAGIC_BYTES_LEN = SNAPPY_MAGIC_BYTES.length,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lodash": ">3.0 <4.0",
     "node-uuid": "~1.4.3",
     "node-zookeeper-client": "~0.2.2",
-    "retry": "~0.6.1",
+    "optional": "^0.1.3",
+    "retry": "~0.6.1"
+  },
+  "optionalDependencies": {
     "snappy": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There will still be errors shown (below) for environments without the right dependencies to install snappy but the `npm install` finishes successfully.

```
npm info lifecycle snappy@4.1.2~install: snappy@4.1.2

> snappy@4.1.2 install /kafka-node/node_modules/snappy
> node-gyp rebuild

gyp info it worked if it ends with ok
gyp info using node-gyp@3.3.1
gyp info using node@5.10.0 | linux | x64
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
gyp ERR! stack     at failNoPython (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:401:14)
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:330:11
gyp ERR! stack     at F (/usr/local/lib/node_modules/npm/node_modules/which/which.js:63:16)
gyp ERR! stack     at E (/usr/local/lib/node_modules/npm/node_modules/which/which.js:72:29)
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/which.js:81:16
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/index.js:44:5
gyp ERR! stack     at /usr/local/lib/node_modules/npm/node_modules/which/node_modules/isexe/access.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:82:15)
gyp ERR! System Linux 4.1.19-boot2docker
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /kafka-node/node_modules/snappy
gyp ERR! node -v v5.10.0
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
npm info lifecycle snappy@4.1.2~install: Failed to exec install script
npm WARN install:snappy@4.1.2 snappy@4.1.2 install: `node-gyp rebuild`
npm WARN install:snappy@4.1.2 Exit status 1
```