### PR TITLE
Update highLevelConsumer.js

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -143,7 +143,9 @@ HighLevelConsumer.prototype.connect = function () {
 
         if (!self.rebalancing) {
             deregister();
-
+            
+            self.ready = false;
+            
             self.emit('rebalancing');
 
             self.rebalancing = true;


### PR DESCRIPTION
If highLevelConsumer try to fetch a message when it is rebalancing, it maybe cause consumer reconsume message from min offset.
I find some issues:
https://github.com/SOHU-Co/kafka-node/issues/350
https://github.com/SOHU-Co/kafka-node/issues/235
