### PR TITLE
Fixing keyed partitioner

### DIFF
--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -54,10 +54,14 @@ KeyedPartitioner.prototype.hashCode = function(string) {
 };
 
 KeyedPartitioner.prototype.getPartition = function (partitions, key) {
-    key = key || '';
+    if (partitions.length>0) {
+      key = key || '';
 
-    var index = this.hashCode(key) % partitions.length;
-    return partitions[index];
+      var index = this.hashCode(key) % partitions.length;
+      return partitions[index];
+    } else {
+      return 0;
+    }
 };
 
 module.exports.DefaultPartitioner = DefaultPartitioner;

--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -50,7 +50,7 @@ KeyedPartitioner.prototype.hashCode = function(string) {
         hash = ((hash * 31) + string.charCodeAt(i)) & 0x7fffffff;
     }
 
-    return (hash === 0) ? 1 : hash;
+    return (hash === 0) ? 0 : hash;
 };
 
 KeyedPartitioner.prototype.getPartition = function (partitions, key) {

--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -50,7 +50,7 @@ KeyedPartitioner.prototype.hashCode = function(string) {
         hash = ((hash * 31) + string.charCodeAt(i)) & 0x7fffffff;
     }
 
-    return (hash === 0) ? 0 : hash;
+    return (hash === 0) ? 1 : hash;
 };
 
 KeyedPartitioner.prototype.getPartition = function (partitions, key) {


### PR DESCRIPTION
This pull request solves the problem of https://github.com/SOHU-Co/kafka-node/issues/354

When sending the first events with the producer, the topic metadata is not yet updated and the partitions array is empty. It causes the partitioner to return `NaN` which fails the producer.

This pull request returns 0 as the chosen partition as long as the partitions array is empty.

It still feels like a workaround, since I would expect the producer to update the metadata before firing the `ready` event. So it would be great if anyone could pick that up.