### PR TITLE
Remove unused config resolves #363

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -9,7 +9,6 @@ var DEFAULTS = {
   groupId: 'kafka-node-group',
   // Auto commit config
   autoCommit: true,
-  autoCommitMsgCount: 100,
   autoCommitIntervalMs: 5000,
   // Fetch message config
   fetchMaxWaitMs: 100,

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -13,7 +13,6 @@ var DEFAULTS = {
   groupId: 'kafka-node-group',
   // Auto commit config
   autoCommit: true,
-  autoCommitMsgCount: 100,
   autoCommitIntervalMs: 5000,
   // Fetch message config
   fetchMaxWaitMs: 100,

--- a/test/test.consumer.js
+++ b/test/test.consumer.js
@@ -291,7 +291,6 @@ function offsetOutOfRange (topic, consumer) {
           var defaults = {
             groupId: 'kafka-node-group',
             autoCommit: true,
-            autoCommitMsgCount: 100,
             autoCommitIntervalMs: 5000,
             encoding: 'utf8',
             fetchMaxWaitMs: 100,


### PR DESCRIPTION
Removes unused `autoCommitMsgCount` option.

Resolves #363 