### PR TITLE
Added coverage reporting with coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ before_install:
 after_failure:
   - docker ps
   - docker-compose logs
+after_success:
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Kafka-node
 
 [![NPM](https://nodei.co/npm/kafka-node.png)](https://nodei.co/npm/kafka-node/)
 [![NPM](https://nodei.co/npm-dl/kafka-node.png?height=3)](https://nodei.co/npm/kafka-node/)
+[![Build Status](https://travis-ci.org/SOHU-Co/kafka-node.svg?branch=master)](https://travis-ci.org/SOHU-Co/kafka-node)
+[![Coverage Status](https://coveralls.io/repos/github/SOHU-Co/kafka-node/badge.svg?branch=master)](https://coveralls.io/github/SOHU-Co/kafka-node?branch=master)
 
 Kafka-node is a Node.js client with Zookeeper integration for Apache Kafka 0.8.1 and later.
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "snappy": "^5.0.5"
   },
   "devDependencies": {
+    "coveralls": "^2.11.12",
     "doctoc": "^1.2.0",
     "eslint": "^2.13.1",
     "eslint-config-semistandard": "^6.0.2",


### PR DESCRIPTION
Adds code coverage reporting using Coveralls. This uses the existing code coverage tools, it just adds a final step to Travis CI to report the lcov.info information to coveralls on success.

To see what the coveralls tool will look like, you can see [my fork](https://coveralls.io/github/lightswitch05/kafka-node).

Note: To enable coveralls integration with this original repo, it does require you to log into [coveralls.io](https://coveralls.io/) and allow github integration. The account is free, but I understand if that isn't something you want.