### PR TITLE
Fixes #427 stop relying on deprecated host and port config from kafka

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,13 +97,17 @@ Client.prototype.connect = function () {
     }
   });
   zk.on('brokersChanged', function (brokerMetadata) {
-    self.brokerMetadata = brokerMetadata;
-    self.setupBrokerProfiles(brokerMetadata);
-    self.refreshBrokers();
-    // Emit after a 3 seconds
-    setTimeout(function () {
-      self.emit('brokersChanged');
-    }, 3000);
+    try {
+      self.brokerMetadata = brokerMetadata;
+      self.setupBrokerProfiles(brokerMetadata);
+      self.refreshBrokers();
+      // Emit after a 3 seconds
+      setTimeout(function () {
+        self.emit('brokersChanged');
+      }, 3000);
+    } catch (error) {
+      self.emit('error', error);
+    }
   });
   zk.once('disconnected', function () {
     if (!zk.closed) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -78,22 +78,28 @@ Client.prototype.connect = function () {
   var zk = this.zk = new Zookeeper(this.connectionString, this.zkOptions);
   var self = this;
   zk.once('init', function (brokers) {
-    self.ready = true;
-    self.brokerMetadata = brokers;
-    self.setupBrokerProfiles(brokers);
-    Object
-        .keys(brokers)
-        .some(function (key, index) {
-          var broker = brokers[key];
-          self.setupBroker(broker.host, broker.port, false, self.brokers);
-          // Only connect one broker
-          return !index;
-        });
-    self.emit('ready');
+    try {
+      self.ready = true;
+      self.brokerMetadata = brokers;
+      self.setupBrokerProfiles(brokers);
+      Object
+          .keys(self.brokerProfiles)
+          .some(function (key, index) {
+            var broker = self.brokerProfiles[key];
+            self.setupBroker(broker.host, broker.port, false, self.brokers);
+            // Only connect one broker
+            return !index;
+          });
+      self.emit('ready');
+    } catch (error) {
+      self.ready = false;
+      self.emit('error', error);
+    }
   });
   zk.on('brokersChanged', function (brokerMetadata) {
-    self.refreshBrokers(brokerMetadata);
+    self.brokerMetadata = brokerMetadata;
     self.setupBrokerProfiles(brokerMetadata);
+    self.refreshBrokers();
     // Emit after a 3 seconds
     setTimeout(function () {
       self.emit('brokersChanged');
@@ -114,25 +120,34 @@ Client.prototype.connect = function () {
 Client.prototype.setupBrokerProfiles = function (brokers) {
   this.brokerProfiles = Object.create(null);
   var self = this;
+  var protocol = self.ssl ? 'ssl:' : 'plaintext:';
 
   Object.keys(brokers).forEach(function (key) {
     var brokerProfile = brokers[key];
-    var addr = brokerProfile.host + ':' + brokerProfile.port;
-    self.brokerProfiles[addr] = brokerProfile;
-    if (self.ssl) {
-      var sslAddress = brokerProfile.endpoints.find(function (endpoint) {
-        return url.parse(endpoint).protocol === 'ssl:';
-      });
-      if (!sslAddress) {
-        var err = new Error(['No SSL kafka endpoint found for broker: ', addr, ' [', key, ']'].join(''));
-        self.emit('error', err);
-        return;
-      }
-      var sslUrl = url.parse(sslAddress);
+    var addr;
 
-      brokerProfile.sslHost = sslUrl.hostname;
-      brokerProfile.sslPort = +sslUrl.port;
+    if (brokerProfile.endpoints && brokerProfile.endpoints.length) {
+      var endpoint = brokerProfile.endpoints.find(function (endpoint) {
+        return url.parse(endpoint).protocol === protocol;
+      });
+
+      if (endpoint == null) {
+        throw new Error(['No kafka endpoint found for broker: ', key, ' with protocol ', protocol].join(''));
+      }
+
+      var endpointUrl = url.parse(endpoint);
+
+      addr = endpointUrl.hostname + ':' + endpointUrl.port;
+
+      brokerProfile.host = endpointUrl.hostname;
+      brokerProfile.port = endpointUrl.port;
+    } else {
+      addr = brokerProfile.host + ':' + brokerProfile.port;
     }
+    assert(brokerProfile.host && brokerProfile.port, 'kafka host or port is empty');
+
+    self.brokerProfiles[addr] = brokerProfile;
+    self.brokerProfiles[addr].id = key;
   });
 };
 
@@ -371,19 +386,23 @@ Client.prototype.nextSocketId = function () {
   return this._socketId++;
 };
 
-Client.prototype.refreshBrokers = function (brokerMetadata) {
+Client.prototype.refreshBrokers = function () {
   var self = this;
-  this.brokerMetadata = brokerMetadata;
-  deleteDeadBrokers(this.brokers);
-  deleteDeadBrokers(this.longpollingBrokers);
-  function deleteDeadBrokers (brokers) {
-    Object.keys(brokers).filter(function (k) {
-      return !~_.values(brokerMetadata).map(function (b) { return b.host + ':' + b.port; }).indexOf(k);
-    }).forEach(function (deadKey) {
-      self.closeBrokers([brokers[deadKey]]);
-      delete brokers[deadKey];
-    });
+  var validBrokers = Object.keys(this.brokerProfiles);
+
+  function closeDeadBrokers (brokers) {
+    var deadBrokerKeys = _.difference(Object.keys(brokers), validBrokers);
+    if (deadBrokerKeys.length) {
+      self.closeBrokers(deadBrokerKeys.map(function (key) {
+        var broker = brokers[key];
+        delete brokers[key];
+        return broker;
+      }));
+    }
   }
+
+  closeDeadBrokers(this.brokers);
+  closeDeadBrokers(this.longpollingBrokers);
 };
 
 Client.prototype.refreshMetadata = function (topicNames, cb) {
@@ -537,31 +556,20 @@ Client.prototype.brokerForLeader = function (leader, longpolling) {
       return;
     }
   }
-  var metadata = this.brokerMetadata[leader];
-  addr = metadata.host + ':' + metadata.port;
-  return brokers[addr] || this.setupBroker(metadata.host, metadata.port, longpolling, brokers);
+
+  var broker = _.find(this.brokerProfiles, {id: leader});
+  addr = broker.host + ':' + broker.port;
+
+  return brokers[addr] || this.setupBroker(broker.host, broker.port, longpolling, brokers);
 };
 
 Client.prototype.getBrokers = function (longpolling) {
   return longpolling ? this.longpollingBrokers : this.brokers;
 };
 
-Client.prototype.lookupBrokerProfile = function (host, port, key) {
-  var profile = this.brokerProfiles[key];
-  return {
-    host: profile[this.ssl ? 'sslHost' : 'host'] || host,
-    port: profile[this.ssl ? 'sslPort' : 'port'] || port
-  };
-};
-
-Client.prototype.setupBroker = function (host, port, longpolling, brokers, brokerKey) {
-  // prefer host and port from broker discovery
-  // this gets populated by the initial discovery of brokers from kafka
-  if (brokerKey == null) {
-    brokerKey = host + ':' + port;
-  }
-  var brokerInfo = this.lookupBrokerProfile(host, port, brokerKey);
-  brokers[brokerKey] = this.createBroker(brokerInfo.host, brokerInfo.port, longpolling);
+Client.prototype.setupBroker = function (host, port, longpolling, brokers) {
+  var brokerKey = host + ':' + port;
+  brokers[brokerKey] = this.createBroker(host, port, longpolling);
   return brokers[brokerKey];
 };
 
@@ -629,12 +637,7 @@ Client.prototype.reconnectBroker = function (oldSocket) {
     oldSocket.destroy();
   }
   var brokers = this.getBrokers(oldSocket.longpolling);
-  var brokerKey = oldSocket.addr;
-  if (!(brokerKey in brokers)) {
-    assert(this.ssl, 'brokerKey not found in brokers and not SSL');
-    brokerKey = _.findKey(this.brokerProfiles, {sslHost: oldSocket.host, sslPort: oldSocket.port});
-  }
-  var newBroker = this.setupBroker(oldSocket.host, oldSocket.port, oldSocket.longpolling, brokers, brokerKey);
+  var newBroker = this.setupBroker(oldSocket.host, oldSocket.port, oldSocket.longpolling, brokers);
   newBroker.socket.error = oldSocket.error;
 };
 


### PR DESCRIPTION
To reproduce this issue locally.

Update `docker-compose.yml`:

```yml
version: '2'
services:
  zookeeper:
    image: wurstmeister/zookeeper
    ports:
      - "2181:2181"
  kafka:
    image: wurstmeister/kafka:latest
    ports:
      - "9093:9093"
    depends_on:
      - zookeeper
    environment:
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_LISTENERS: "SSL://:9093"
      KAFKA_ADVERTISED_LISTENERS: "SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093"
      KAFKA_SSL_KEYSTORE_LOCATION: "/var/private/ssl/certs/server.keystore.jks"
      KAFKA_SSL_KEYSTORE_PASSWORD: "password"
      KAFKA_SSL_KEY_PASSWORD: "password"
      KAFKA_SSL_TRUSTSTORE_LOCATION: "/var/private/ssl/certs/server.truststore.jks"
      KAFKA_SSL_TRUSTSTORE_PASSWORD: "password"
      KAFKA_CREATE_TOPICS: "RebalanceTopic:3:1"
      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "SSL"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ./docker/certs:/var/private/ssl/certs
      - ./docker/start-kafka.sh:/usr/bin/start-kafka.sh
```

Add `./docker/start-kafka.sh`

```bash
#!/bin/bash

if [[ -z "$KAFKA_BROKER_ID" ]]; then
    # By default auto allocate broker ID
    export KAFKA_BROKER_ID=-1
fi
if [[ -z "$KAFKA_LOG_DIRS" ]]; then
    export KAFKA_LOG_DIRS="/kafka/kafka-logs-$HOSTNAME"
fi
if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
    export KAFKA_ZOOKEEPER_CONNECT=$(env | grep ZK.*PORT_2181_TCP= | sed -e 's|.*tcp://||' | paste -sd ,)
fi

if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
    sed -r -i "s/(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
    unset KAFKA_HEAP_OPTS
fi

for VAR in `env`
do
  if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
    kafka_name=`echo "$VAR" | sed -r "s/KAFKA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
    env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
    if egrep -q "(^|^#)$kafka_name=" $KAFKA_HOME/config/server.properties; then
        sed -r -i "s@(^|^#)($kafka_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/server.properties #note that no config values may contain an '@' char
    else
        echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
    fi
  fi
done

KAFKA_PID=0

# see https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86#.bh35ir4u5
term_handler() {
  echo 'Stopping Kafka....'
  if [ $KAFKA_PID -ne 0 ]; then
    kill -s TERM "$KAFKA_PID"
    wait "$KAFKA_PID"
  fi
  echo 'Kafka stopped.'
  exit
}


# Capture kill requests to stop properly
trap "term_handler" SIGHUP SIGINT SIGTERM
create-topics.sh &
$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
KAFKA_PID=$!

wait
```