### PR TITLE
Enable topic deletion by emitting event 'unknownTopicOrPartition' instead of 'brokerChanged'.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -176,7 +176,9 @@ Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs
     if (err) {
       if (err.message === 'OffsetOutOfRange') {
         return consumer.emit('offsetOutOfRange', err);
-      } else if (err.message === 'NotLeaderForPartition' || err.message === 'UnknownTopicOrPartition') {
+      } else if (err.message === 'UnknownTopicOrPartition') {
+        return consumer.emit('unknownTopicOrPartition', err);
+      }else if (err.message === 'NotLeaderForPartition') {
         return self.emit('brokersChanged');
       }
 


### PR DESCRIPTION
When broker is configured for both auto topic creation and log compaction, then the client will receive an 'UnknownTopicOrPartition' event when the broker cleans up a topic.
Currently this event is converted to a 'brokersChanged' event which will result in fetching all the known metadata.  The result of fetching will cause the broker to auto create the topic again.  This effectively means a topic can never be deleted, either by the broker or manually.

Instead an 'unknownTopicOrPartition' is emitted and the user must handle it by removing the topic from the consumer, otherwise the metadata will cause auto topic creation again.

```
consumer.on('unknownTopicOrPartition', function(err){
  consumer.pause()
  var topic = err.topic
  consumer.removeTopics([topic], function(err){
    console.log('UnknownTopicOrPartition: removed topic', topic)
    consumer.resume()
  })
})
```
