### PR TITLE
for...in loops must check for hasOwnProperty

### DIFF
--- a/lib/assignment/range.js
+++ b/lib/assignment/range.js
@@ -14,6 +14,9 @@ function assignRange (topicPartition, groupMembers, callback) {
 
   const topicMemberMap = topicToMemberMap(groupMembers);
   for (var topic in topicMemberMap) {
+    if (!topicMemberMap.hasOwnProperty(topic)) {
+      continue;
+    }
     debug('For topic %s', topic);
     topicMemberMap[topic].sort();
     debug('   members: ', topicMemberMap[topic]);

--- a/lib/client.js
+++ b/lib/client.js
@@ -524,6 +524,9 @@ Client.prototype.sendToBroker = function (payloads, encoder, decoder, cb) {
     cb = wrap(payloads, cb);
   }
   for (var leader in payloads) {
+    if (!payloads.hasOwnProperty(leader)) {
+      continue;
+    }
     var correlationId = this.nextId();
     var request = encoder(this.clientId, correlationId, payloads[leader]);
     var broker = this.brokerForLeader(leader, longpolling);
@@ -568,6 +571,9 @@ Client.prototype.updateMetadatas = function (metadatas) {
   // _.extend(this.brokerMetadata, metadatas[0])
   _.extend(this.topicMetadata, metadatas[1].metadata);
   for (var topic in this.topicMetadata) {
+    if (!this.topicMetadata.hasOwnProperty(topic)) {
+      continue;
+    }
     this.topicPartitions[topic] = Object.keys(this.topicMetadata[topic]).map(function (val) {
       return parseInt(val, 10);
     });

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -387,6 +387,9 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
       debug('HighLevelConsumer %s determining the partitions to own during rebalance', self.id);
       debug('consumerPerTopicMap.consumerTopicMap %j', consumerPerTopicMap.consumerTopicMap);
       for (var topic in consumerPerTopicMap.consumerTopicMap[self.id]) {
+        if (!consumerPerTopicMap.consumerTopicMap[self.id].hasOwnProperty(topic)) {
+          continue;
+        }
         var topicToAdd = consumerPerTopicMap.consumerTopicMap[self.id][topic];
         var numberOfConsumers = consumerPerTopicMap.topicConsumerMap[topicToAdd].length;
         var numberOfPartition = consumerPerTopicMap.topicPartitionMap[topicToAdd].length;
@@ -394,6 +397,9 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
         var extraPartitions = numberOfPartition % numberOfConsumers;
         var currentConsumerIndex;
         for (var index in consumerPerTopicMap.topicConsumerMap[topicToAdd]) {
+          if (!consumerPerTopicMap.topicConsumerMap[topicToAdd].hasOwnProperty(index)) {
+            continue;
+          }
           if (consumerPerTopicMap.topicConsumerMap[topicToAdd][index] === self.id) {
             currentConsumerIndex = parseInt(index);
             break;

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -830,6 +830,9 @@ function _encodeMemberAssignment (assignment) {
     .Int32BE(numberOfTopics);
 
   for (var tp in assignment.topicPartitions) {
+    if (!assignment.topicPartitions.hasOwnProperty(tp)) {
+      continue;
+    }
     var partitions = assignment.topicPartitions[tp];
     assignmentByte.Int16BE(tp.length).string(tp)
       .Int32BE(partitions.length);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,6 +65,9 @@ Into a topic partition payload:
 function createTopicPartitionList (topicPartitions) {
   var tpList = [];
   for (var topic in topicPartitions) {
+    if (!topicPartitions.hasOwnProperty(topic)) {
+      continue;
+    }
     topicPartitions[topic].forEach(function (partition) {
       tpList.push({
         topic: topic,

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -142,6 +142,9 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
                     var obj = JSON.parse(data.toString());
                     // For each topic
                     for (var topic in obj.subscription) {
+                      if (!obj.subscription.hasOwnProperty(topic)) {
+                        continue;
+                      }
                       if (consumerPerTopicMap.topicConsumerMap[topic] == null) {
                         consumerPerTopicMap.topicConsumerMap[topic] = [];
                       }


### PR DESCRIPTION
`for...in` is dangerous in JavaScript. When used, one must use the hasOwnProperty() test:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only

Example: kafka-node kept crashing when used together with another library that defined a polyfill for `Object.values()` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values:

``` javascript
if (!Object.values) {
    Object.prototype.values = function (obj) {
        return Object.keys(obj).map(function (key) {
            return obj[key];
        });
    };
}
```

All the `for .. in` loops in kafka-node would iterate over an additional property `values`, which will then make kafka-node to crash.

Note: I tried to run the tests as documented (including installing Docker), but the procedure did not seem to immediately work on Ubuntu 16.04; so I count on Travis...
