### PR TITLE
Adding new util function for topics validations

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ function validateConfig (property, value) {
   }
 }
 
-function validateCreateTopics(topics) {
+function validateCreateTopics (topics) {
   // Rewriting same validations done by Apache Kafka team for topics
   // iterating over topics
   topics.some(function (topic) {
@@ -23,7 +23,7 @@ function validateCreateTopics(topics) {
       throw new InvalidConfigError('topic name is illegal, cannot be longer than ' + allowedTopicLength + ' characters');
     }
     if (!legalChars.test(topic)) {
-      throw new InvalidConfigError('topic name ' +topic+ 'is illegal, contains a character other than ASCII alphanumerics .,_ and -');
+      throw new InvalidConfigError('topic name ' + topic + 'is illegal, contains a character other than ASCII alphanumerics .,_ and -');
     }
   });
   return true;
@@ -100,5 +100,6 @@ module.exports = {
   validateConfig: validateConfig,
   validateTopics: validateTopics,
   groupPartitionsByTopic: groupPartitionsByTopic,
-  createTopicPartitionList: createTopicPartitionList
+  createTopicPartitionList: createTopicPartitionList,
+  validateCreateTopics: validateCreateTopics
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,32 @@
 var assert = require('assert');
 var InvalidConfigError = require('./errors/InvalidConfigError');
 var legalChars = new RegExp('^[a-zA-Z0-9._-]*$');
+var allowedTopicLength = 249;
 
 function validateConfig (property, value) {
   if (!legalChars.test(value)) {
     throw new InvalidConfigError([property, value, "is illegal, contains a character other than ASCII alphanumerics, '.', '_' and '-'"].join(' '));
   }
+}
+
+function validateCreateTopics(topics) {
+  // Rewriting same validations done by Apache Kafka team for topics
+  // iterating over topics
+  topics.some(function (topic) {
+    if (topic.length <= 0) {
+      throw new InvalidConfigError('topic name is illegal, cannot be empty');
+    }
+    if (topic === '.' || topic === '..') {
+      throw new InvalidConfigError('topic name cannot be . or ..');
+    }
+    if (topic.length > allowedTopicLength) {
+      throw new InvalidConfigError('topic name is illegal, cannot be longer than ' + allowedTopicLength + ' characters');
+    }
+    if (!legalChars.test(topic)) {
+      throw new InvalidConfigError('topic name ' +topic+ 'is illegal, contains a character other than ASCII alphanumerics .,_ and -');
+    }
+  });
+  return true;
 }
 
 function validateTopics (topics) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var InvalidConfigError = require('./errors/InvalidConfigError');
 var legalChars = new RegExp('^[a-zA-Z0-9._-]*$');
-var allowedTopicLength = 249;
+const allowedTopicLength = 249;
 
 function validateConfig (property, value) {
   if (!legalChars.test(value)) {
@@ -9,7 +9,7 @@ function validateConfig (property, value) {
   }
 }
 
-function validateCreateTopics (topics) {
+function validateTopicNames (topics) {
   // Rewriting same validations done by Apache Kafka team for topics
   // iterating over topics
   topics.some(function (topic) {
@@ -20,10 +20,10 @@ function validateCreateTopics (topics) {
       throw new InvalidConfigError('topic name cannot be . or ..');
     }
     if (topic.length > allowedTopicLength) {
-      throw new InvalidConfigError('topic name is illegal, cannot be longer than ' + allowedTopicLength + ' characters');
+      throw new InvalidConfigError(`topic name is illegal, cannot be longer than ${allowedTopicLength} characters`);
     }
     if (!legalChars.test(topic)) {
-      throw new InvalidConfigError('topic name ' + topic + 'is illegal, contains a character other than ASCII alphanumerics .,_ and -');
+      throw new InvalidConfigError(`topic name ${topic} is illegal, contains a character other than ASCII alphanumerics .,_ and -`);
     }
   });
   return true;
@@ -101,5 +101,5 @@ module.exports = {
   validateTopics: validateTopics,
   groupPartitionsByTopic: groupPartitionsByTopic,
   createTopicPartitionList: createTopicPartitionList,
-  validateCreateTopics: validateCreateTopics
+  validateTopicNames: validateTopicNames
 };


### PR DESCRIPTION
Leaving the `validateTopics` topics function as it is because I believe it is meant for validating the topics coming from the `send()` function. Not sure, though.

`validateCreateTopics` contains following checks which are similar to what is been done for Kafka here [https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/common/Topic.scala]

- check if the topic is empty.
- check if the topic is . or ..
- check if the topic length is greater than 249 characters.
- check if the topic, is not ASCII alphanumeric.