### PR TITLE
Upgrade nested-error-stacks to v2 for node v7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.1.3",
     "lodash": ">3.0 <4.0",
     "minimatch": "^3.0.2",
-    "nested-error-stacks": "^1.0.2",
+    "nested-error-stacks": "^2.0.0",
     "node-zookeeper-client": "~0.2.2",
     "optional": "^0.1.3",
     "retry": "~0.6.1",


### PR DESCRIPTION
Before nested-error-stacks v2, building nested errors in node v7 did not work correctly. Upgrading the dependency will allow kafka-node to avoid those problems in node v7