### PR TITLE
Allow configuration of rebalance retry strategy on HighLevelConsumer

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -22,7 +22,14 @@ var DEFAULTS = {
   fetchMinBytes: 1,
   fetchMaxBytes: 1024 * 1024,
   maxTickMessages: 1000,
-  fromOffset: false
+  fromOffset: false,
+  rebalanceRetry: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 1 * 100,
+    maxTimeout: 1 * 1000,
+    randomize: true
+  }
 };
 
 var HighLevelConsumer = function (client, topics, options) {
@@ -160,15 +167,9 @@ HighLevelConsumer.prototype.connect = function () {
       self.emit('rebalancing');
 
       self.rebalancing = true;
-      // Nasty hack to retry 3 times to re-balance - TBD fix this
+      debug('HighLevelConsumer rebalance retry config: %s', JSON.stringify(self.options.rebalanceRetry));
       var oldTopicPayloads = self.topicPayloads;
-      var operation = retry.operation({
-        retries: 10,
-        factor: 2,
-        minTimeout: 1 * 100,
-        maxTimeout: 1 * 1000,
-        randomize: true
-      });
+      var operation = retry.operation(self.options.rebalanceRetry);
 
       operation.attempt(function (currentAttempt) {
         self.rebalanceAttempt(oldTopicPayloads, function (err) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nested-error-stacks": "^2.0.0",
     "node-zookeeper-client": "~0.2.2",
     "optional": "^0.1.3",
-    "retry": "~0.6.1",
+    "retry": "^0.10.1",
     "uuid": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
  - This proposal is to address https://github.com/SOHU-Co/kafka-node/issues/541 (HighLevelConsumer leaving partitions without owner on multiple consumers startup). After doing several tests and observations, I believe this (bad) resulting scenario may be caused by race conditions of several consumers trying to consume same partitions and library not handling correctly the retries. Therefore the idea is to allow the rebalance retries to be configurable for each scenario. Particularly, I got good results when setting each consumer with a different (randomised) cycle of retry, to avoid collisions on attempts.
  - The change is not breaking at all.
  - Also is included a bump on retry library (used on rebalancing action) to version 0.7.0 which introduces a couple of bugfixes. The most important fix introduced is https://github.com/tim-kos/node-retry/issues/12