### PR TITLE
reducing autocommit fires when consumer is idle

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -509,16 +509,18 @@ HighLevelConsumer.prototype.init = function () {
  * @param {Boolean} Don't commit when initing consumer
  */
 HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
+  var changed = false;
   this.topicPayloads.forEach(function (p) {
     if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined) {
       var offset = topics[p.topic][p.partition];
       if (offset === -1) offset = 0;
       if (!initing) p.offset = offset + 1;
       else p.offset = offset;
+      changed = true;
     }
   });
 
-  if (this.options.autoCommit && !initing) {
+  if (this.options.autoCommit && changed && !initing) {
     this.autoCommit(false, function (err) {
       err && debug('auto commit offset', err);
     });


### PR DESCRIPTION
in `HighLevelConsumer.updateOffsets` autoCommit was being called
regardless if the connected topics were updated or not, causing
autocommit to be called frequently with the same offsets already in
place