### PR TITLE
Allow custom logging implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # kafka-node CHANGELOG
 
+## Unreleased
+- Logging strategy should be configurable so that `kafka-node` can be integrated into applications more easily.
+
 ## 2017-02-01, Version 1.3.4
 - Producers should better recover from brokers going offline and coming back [#580](https://github.com/SOHU-Co/kafka-node/pull/580)
 
@@ -42,7 +45,7 @@
 ## 2016-11-18, Version 1.0.7
 - Fix issue where `createTopics` using the `async` set to `false` was not synchronous. [#519](https://github.com/SOHU-Co/kafka-node/pull/519)
 
-   **NOTE**: The behavior now is if `async` is true the callback is not actually called until all the topics are confirmed to have been created by Kafka. The previous behavior the callback would be called after the first request (which does not guarantee the topics have been created). This wasn't consistent with what the doc said. 
+   **NOTE**: The behavior now is if `async` is true the callback is not actually called until all the topics are confirmed to have been created by Kafka. The previous behavior the callback would be called after the first request (which does not guarantee the topics have been created). This wasn't consistent with what the doc said.
 
 - Fix issue where messages are lost when sending a batch of keyed messages using the highLevelPartitioner [#521](https://github.com/SOHU-Co/kafka-node/pull/521)
 - Upgrade UUID package [#520](https://github.com/SOHU-Co/kafka-node/pull/520)
@@ -74,9 +77,9 @@
 
 Major version change since we're dropping support for Node older than v4.
 
-Added a new Consumer called [Consumer Group](https://github.com/SOHU-Co/kafka-node#consumergroup) this is supported in Kafka 0.9 and greater. [#477](https://github.com/SOHU-Co/kafka-node/pull/477) 
+Added a new Consumer called [Consumer Group](https://github.com/SOHU-Co/kafka-node#consumergroup) this is supported in Kafka 0.9 and greater. [#477](https://github.com/SOHU-Co/kafka-node/pull/477)
 
-* Add group membership API protocols 
+* Add group membership API protocols
 * Add consumerGroup roundrobin assignment
 * Add documentation for ConsumerGroup
 * Implemented range assignment strategy
@@ -91,7 +94,7 @@ Added a new Consumer called [Consumer Group](https://github.com/SOHU-Co/kafka-no
 ## 2016-10-03, Version 0.5.9
 - Fix issue with highLevelConsumers and how consumer groups react to zookeeper redeploys creating a lot of [NODE_EXISTS] errors [#472](https://github.com/SOHU-Co/kafka-node/pull/472)
 - Removed docker-machine support for tests [#474](https://github.com/SOHU-Co/kafka-node/pull/474)
-- Minor fixes and additions to doc [#475](https://github.com/SOHU-Co/kafka-node/pull/475) [#471](https://github.com/SOHU-Co/kafka-node/pull/471) 
+- Minor fixes and additions to doc [#475](https://github.com/SOHU-Co/kafka-node/pull/475) [#471](https://github.com/SOHU-Co/kafka-node/pull/471)
 
 ## 2016-09-12, Version 0.5.8
 - Fix duplicate messages consumed on startup this was triggered by unnecessary rebalance (versions affected: *v0.5.4* to *v0.5.7*) [#465](https://github.com/SOHU-Co/kafka-node/pull/465)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Kafka-node is a Node.js client with Zookeeper integration for Apache Kafka 0.8.1
   - [How to throttle messages / control the concurrency of processing messages](#how-to-throttle-messages--control-the-concurrency-of-processing-messages)
   - [How do I produce and consume binary data?](#how-do-i-produce-and-consume-binary-data)
   - [What are these node-gyp and snappy errors?](#what-are-these-node-gyp-and-snappy-errors)
+  - [How do I configure the log output?](#how-do-i-configure-the-log-output)
 - [Running Tests](#running-tests)
 - [LICENSE - "MIT"](#license---mit)
 
@@ -935,6 +936,41 @@ npm install kafka-node --no-optional --save
 ```
 
 Keep in mind if you try to use snappy without installing it `kafka-node` will throw a runtime exception.
+
+## How do I configure the log output?
+
+By default, `kafka-node` uses [debug](https://github.com/visionmedia/debug) to log important information. To integrate `kafka-node`'s log output into an application, it is possible to set a logger provider. This enables filtering of log levels and easy redirection of output streams.
+
+### What is a logger provider?
+
+A logger provider is a function which takes the name of a logger and returns a logger implementation. For instance, the following code snippet shows how a logger provider for the global `console` object could be written:
+
+```javascript
+function consoleLoggerProvider (name) {
+  // do something with the name
+  return {
+    debug: console.debug.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console)
+  };
+}
+```
+
+The logger interface with its `debug`, `info`, `warn` and `error` methods expects format string support as seen in `debug` or the JavaScript `console` object. Many commonly used logging implementations cover this API, e.g. bunyan, pino or winston.
+
+### How do I set a logger provider?
+
+For performance reasons, initialization of the `kafka-node` module creates all necessary loggers. This means that custom logger providers need to be set *before requiring the `kafka-node` module*. The following example shows how this can be done:
+
+```javascript
+// first configure the logger provider
+const kafkaLogging = require('kafka-node/logging');
+kafkaLogging.setLoggerProvider(consoleLoggerProvider);
+
+// then require kafka-node and continue as normal
+const kafka = require('kafka-node');
+```
 
 # Running Tests
 

--- a/lib/assignment/range.js
+++ b/lib/assignment/range.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const debug = require('debug')('kafka-node:Range');
+const logger = require('../logging')('kafka-node:Range');
 const VERSION = 0;
 const _ = require('lodash');
 const groupPartitionsByTopic = require('../utils').groupPartitionsByTopic;
 
 function assignRange (topicPartition, groupMembers, callback) {
-  debug('topicPartition: %j', topicPartition);
+  logger.debug('topicPartition: %j', topicPartition);
   var assignment = _(groupMembers).map('id').reduce(function (obj, id) {
     obj[id] = [];
     return obj;
@@ -17,18 +17,18 @@ function assignRange (topicPartition, groupMembers, callback) {
     if (!topicMemberMap.hasOwnProperty(topic)) {
       continue;
     }
-    debug('For topic %s', topic);
+    logger.debug('For topic %s', topic);
     topicMemberMap[topic].sort();
-    debug('   members: ', topicMemberMap[topic]);
+    logger.debug('   members: ', topicMemberMap[topic]);
 
     var numberOfPartitionsForTopic = topicPartition[topic].length;
-    debug('   numberOfPartitionsForTopic', numberOfPartitionsForTopic);
+    logger.debug('   numberOfPartitionsForTopic', numberOfPartitionsForTopic);
 
     var numberOfMembersForTopic = topicMemberMap[topic].length;
-    debug('   numberOfMembersForTopic', numberOfMembersForTopic);
+    logger.debug('   numberOfMembersForTopic', numberOfMembersForTopic);
 
     var numberPartitionsPerMember = Math.floor(numberOfPartitionsForTopic / numberOfMembersForTopic);
-    debug('   numberPartitionsPerMember', numberPartitionsPerMember);
+    logger.debug('   numberPartitionsPerMember', numberPartitionsPerMember);
 
     var membersWithExtraPartition = numberOfPartitionsForTopic % numberOfMembersForTopic;
     var topicPartitionList = createTopicPartitionArray(topic, numberOfPartitionsForTopic);
@@ -41,7 +41,7 @@ function assignRange (topicPartition, groupMembers, callback) {
     }
   }
 
-  debug(assignment);
+  logger.debug(assignment);
 
   callback(null, convertToAssignmentList(assignment, VERSION));
 }

--- a/lib/assignment/roundrobin.js
+++ b/lib/assignment/roundrobin.js
@@ -2,15 +2,15 @@
 
 var _ = require('lodash');
 var groupPartitionsByTopic = require('../utils').groupPartitionsByTopic;
-var debug = require('debug')('kafka-node:Roundrobin');
+var logger = require('../logging')('kafka-node:Roundrobin');
 var VERSION = 0;
 
 function assignRoundRobin (topicPartition, groupMembers, callback) {
-  debug('topicPartition: %j', topicPartition);
-  debug('groupMembers: %j', groupMembers);
+  logger.debug('topicPartition: %j', topicPartition);
+  logger.debug('groupMembers: %j', groupMembers);
   var _members = _(groupMembers).map('id');
   var members = _members.value().sort();
-  debug('members', members);
+  logger.debug('members', members);
   var assignment = _members.reduce(function (obj, id) {
     obj[id] = [];
     return obj;
@@ -21,7 +21,7 @@ function assignRoundRobin (topicPartition, groupMembers, callback) {
     return subscribers;
   }, {});
 
-  debug('subscribers', subscriberMap);
+  logger.debug('subscribers', subscriberMap);
 
   // layout topic/partitions pairs into a list
   var topicPartitionList = _(topicPartition).map(function (partitions, topic) {
@@ -32,7 +32,7 @@ function assignRoundRobin (topicPartition, groupMembers, callback) {
       };
     });
   }).flatten().value();
-  debug('round robin on topic partition pairs: ', topicPartitionList);
+  logger.debug('round robin on topic partition pairs: ', topicPartitionList);
 
   var assigner = cycle(members);
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,7 @@ var Message = protocol.Message;
 var zk = require('./zookeeper');
 var Zookeeper = zk.Zookeeper;
 var url = require('url');
-var debug = require('debug')('kafka-node:Client');
+var logger = require('./logging')('kafka-node:Client');
 var validateConfig = require('./utils').validateConfig;
 var validateKafkaTopics = require('./utils').validateTopicNames;
 
@@ -102,7 +102,7 @@ Client.prototype.connect = function () {
   zk.on('brokersChanged', function (brokerMetadata) {
     try {
       self.brokerMetadata = brokerMetadata;
-      debug('brokersChanged', brokerMetadata);
+      logger.debug('brokersChanged', brokerMetadata);
       self.setupBrokerProfiles(brokerMetadata);
       self.refreshBrokers();
       // Emit after a 3 seconds
@@ -381,7 +381,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
   const operation = retry.operation({ minTimeout: 200, maxTimeout: 2000 });
 
   operation.attempt(currentAttempt => {
-    debug('create topics currentAttempt', currentAttempt);
+    logger.debug('create topics currentAttempt', currentAttempt);
     getTopicsFromKafka(topics, function (error, kafkaTopics) {
       if (error) {
         if (operation.retry(error)) {
@@ -389,14 +389,14 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
         }
       }
 
-      debug('kafka reported topics', kafkaTopics);
+      logger.debug('kafka reported topics', kafkaTopics);
       const left = _.difference(topics, kafkaTopics);
       if (left.length === 0) {
-        debug(`Topics created ${kafkaTopics}`);
+        logger.debug(`Topics created ${kafkaTopics}`);
         return cb(null);
       }
 
-      debug(`Topics left ${left.join(', ')}`);
+      logger.debug(`Topics left ${left.join(', ')}`);
       if (!operation.retry(new Error(`Topics not created ${left}`))) {
         cb(operation.mainError());
       }
@@ -484,14 +484,14 @@ Client.prototype.refreshMetadata = function (topicNames, cb) {
   function attemptRequestMetadata (topics, cb) {
     var operation = retry.operation({ minTimeout: 200, maxTimeout: 1000 });
     operation.attempt(function (currentAttempt) {
-      debug('refresh metadata currentAttempt', currentAttempt);
+      logger.debug('refresh metadata currentAttempt', currentAttempt);
       self.loadMetadataForTopics(topics, function (err, resp) {
         err = err || resp[1].error;
         if (operation.retry(err)) {
           return;
         }
         if (err) {
-          debug('refresh metadata error', err.message);
+          logger.debug('refresh metadata error', err.message);
           return cb(err);
         }
         self.updateMetadatas(resp);

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -3,7 +3,7 @@
 var util = require('util');
 var _ = require('lodash');
 var events = require('events');
-var debug = require('debug')('kafka-node:Consumer');
+var logger = require('./logging')('kafka-node:Consumer');
 var utils = require('./utils');
 
 var DEFAULTS = {
@@ -68,18 +68,18 @@ Consumer.prototype.connect = function () {
   if (this.ready) this.init();
 
   this.client.on('ready', function () {
-    debug('consumer ready');
+    logger.debug('consumer ready');
     if (!self.ready) self.init();
     self.ready = true;
   });
 
   this.client.on('error', function (err) {
-    debug('client error %s', err.message);
+    logger.error('client error %s', err.message);
     self.emit('error', err);
   });
 
   this.client.on('close', function () {
-    debug('connection closed');
+    logger.debug('connection closed');
   });
 
   this.client.on('brokersChanged', function () {
@@ -146,7 +146,7 @@ Consumer.prototype.updateOffsets = function (topics, initing) {
 
   if (this.options.autoCommit && !initing) {
     this.autoCommit(false, function (err) {
-      err && debug('auto commit offset', err);
+      err && logger.debug('auto commit offset', err);
     });
   }
 };

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('kafka-node:ConsumerGroup');
+const logger = require('./logging')('kafka-node:ConsumerGroup');
 const util = require('util');
 const EventEmitter = require('events');
 const highLevelConsumer = require('./highLevelConsumer');
@@ -98,12 +98,12 @@ function ConsumerGroup (memberOptions, topics) {
   }
 
   this.client.on('error', function (err) {
-    debug('Error from %s', self.client.clientId, err);
+    logger.error('Error from %s', self.client.clientId, err);
     self.emit('error', err);
   });
 
   const recoverFromBrokerChange = _.debounce(function () {
-    debug('brokersChanged refreshing metadata');
+    logger.debug('brokersChanged refreshing metadata');
     self.client.refreshMetadata(self.topics, function (error) {
       if (error) {
         self.emit(error);
@@ -149,7 +149,7 @@ function ConsumerGroup (memberOptions, topics) {
       const offset = _.head(result[topic.topic][topic.partition]);
       const oldOffset = _.find(this.topicPayloads, {topic: topic.topic, partition: topic.partition}).offset;
 
-      debug('replacing %s-%s stale offset of %d with %d', topic.topic, topic.partition, oldOffset, offset);
+      logger.debug('replacing %s-%s stale offset of %d with %d', topic.topic, topic.partition, oldOffset, offset);
 
       this.setOffset(topic.topic, topic.partition, offset);
       this.resume();
@@ -211,8 +211,8 @@ ConsumerGroup.prototype.setCoordinatorId = function (coordinatorId) {
 };
 
 ConsumerGroup.prototype.assignPartitions = function (protocol, groupMembers, callback) {
-  debug('Assigning Partitions to members', groupMembers);
-  debug('Using group protocol', protocol);
+  logger.debug('Assigning Partitions to members', groupMembers);
+  logger.debug('Using group protocol', protocol);
 
   protocol = _.find(this.protocols, {name: protocol});
 
@@ -221,13 +221,13 @@ ConsumerGroup.prototype.assignPartitions = function (protocol, groupMembers, cal
 
   async.waterfall([
     function (callback) {
-      debug('loadingMetadata for topics:', topics);
+      logger.debug('loadingMetadata for topics:', topics);
       self.client.loadMetadataForTopics(topics, callback);
     },
 
     function (metadataResponse, callback) {
       var metadata = mapTopicToPartitions(metadataResponse[1].metadata);
-      debug('mapTopicToPartitions', metadata);
+      logger.debug('mapTopicToPartitions', metadata);
       protocol.assign(metadata, groupMembers, callback);
     }
   ], callback);
@@ -238,7 +238,7 @@ function mapTopicToPartitions (metadata) {
 }
 
 ConsumerGroup.prototype.handleJoinGroup = function (joinGroupResponse, callback) {
-  debug('joinGroupResponse %j from %s', joinGroupResponse, this.client.clientId);
+  logger.debug('joinGroupResponse %j from %s', joinGroupResponse, this.client.clientId);
 
   this.isLeader = (joinGroupResponse.leaderId === joinGroupResponse.memberId);
   this.generationId = joinGroupResponse.generationId;
@@ -271,11 +271,11 @@ ConsumerGroup.prototype.saveDefaultOffsets = function (topicPartitionList, callb
 };
 
 ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback) {
-  debug('SyncGroup Response');
+  logger.debug('SyncGroup Response');
   var self = this;
   var ownedTopics = Object.keys(syncGroupResponse.partitions);
   if (ownedTopics.length) {
-    debug('%s owns topics: ', self.client.clientId, syncGroupResponse.partitions);
+    logger.debug('%s owns topics: ', self.client.clientId, syncGroupResponse.partitions);
 
     const topicPartitionList = createTopicPartitionList(syncGroupResponse.partitions);
     const useDefaultOffsets = self.options.fromOffset in ACCEPTED_FROM_OFFSET;
@@ -285,14 +285,14 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
         self.fetchOffset(syncGroupResponse.partitions, callback);
       },
       function (offsets, callback) {
-        debug('%s fetchOffset Response: %j', self.client.clientId, offsets);
+        logger.debug('%s fetchOffset Response: %j', self.client.clientId, offsets);
 
         var noOffset = topicPartitionList.some(function (tp) {
           return offsets[tp.topic][tp.partition] === -1;
         });
 
         if (noOffset) {
-          debug('No saved offsets');
+          logger.debug('No saved offsets');
 
           if (self.options.fromOffset === 'none') {
             return callback(new Error(`${self.client.clientId} owns topics and partitions which contains no saved offsets for group '${self.options.groupId}'`));
@@ -315,11 +315,11 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
             if (error) {
               return callback(error);
             }
-            debug('%s defaultOffset Response for %s: %j', self.client.clientId, self.options.fromOffset, self.defaultOffsets);
+            logger.debug('%s defaultOffset Response for %s: %j', self.client.clientId, self.options.fromOffset, self.defaultOffsets);
             callback(null, offsets);
           });
         } else {
-          debug('Has saved offsets');
+          logger.debug('Has saved offsets');
           callback(null, offsets);
         }
       },
@@ -363,11 +363,11 @@ function emptyStrIfNull (value) {
 
 ConsumerGroup.prototype.connect = function () {
   if (this.connecting) {
-    debug('Connect ignored. Currently connecting.');
+    logger.warn('Connect ignored. Currently connecting.');
     return;
   }
 
-  debug('Connecting %s', this.client.clientId);
+  logger.debug('Connecting %s', this.client.clientId);
   var self = this;
 
   this.connecting = true;
@@ -382,7 +382,7 @@ ConsumerGroup.prototype.connect = function () {
     },
 
     function (coordinatorInfo, callback) {
-      debug('GroupCoordinator Response:', coordinatorInfo);
+      logger.debug('GroupCoordinator Response:', coordinatorInfo);
       if (coordinatorInfo) {
         self.setCoordinatorId(coordinatorInfo.coordinatorId);
       }
@@ -394,7 +394,7 @@ ConsumerGroup.prototype.connect = function () {
     },
 
     function (groupAssignment, callback) {
-      debug('SyncGroup Request from %s', self.memberId);
+      logger.debug('SyncGroup Request from %s', self.memberId);
       self.client.sendSyncGroupRequest(self.options.groupId, self.generationId, self.memberId, groupAssignment, callback);
     },
 
@@ -411,7 +411,7 @@ ConsumerGroup.prototype.connect = function () {
     self.ready = true;
     self.recovery.clearError();
 
-    debug('generationId', self.generationId);
+    logger.debug('generationId', self.generationId);
 
     if (startFetch) {
       self.fetch();
@@ -443,7 +443,7 @@ ConsumerGroup.prototype.startHeartbeats = function () {
 
   const heartbeatIntervalMs = this.options.heartbeatInterval || (Math.floor(this.options.sessionTimeout / 3));
 
-  debug('%s started heartbeats at every %d ms', this.client.clientId, heartbeatIntervalMs);
+  logger.debug('%s started heartbeats at every %d ms', this.client.clientId, heartbeatIntervalMs);
   this.stopHeartbeats();
 
   let heartbeat = this.sendHeartbeat();
@@ -461,7 +461,7 @@ ConsumerGroup.prototype.stopHeartbeats = function () {
 };
 
 ConsumerGroup.prototype.leaveGroup = function (callback) {
-  debug('%s leaving group', this.client.clientId);
+  logger.debug('%s leaving group', this.client.clientId);
   var self = this;
   this.stopHeartbeats();
   if (self.generationId != null && self.memberId) {
@@ -477,15 +477,15 @@ ConsumerGroup.prototype.leaveGroup = function (callback) {
 ConsumerGroup.prototype.sendHeartbeat = function () {
   assert(this.memberId, 'invalid memberId');
   assert(this.generationId >= 0, 'invalid generationId');
-  // debug('%s ❤️  ->', this.client.clientId);
+  // logger.debug('%s ❤️  ->', this.client.clientId);
   var self = this;
 
   function heartbeatCallback (error) {
     if (error) {
-      debug('%s Heartbeat error:', self.client.clientId, error);
+      logger.warn('%s Heartbeat error:', self.client.clientId, error);
       self.recovery.tryToRecoverFrom(error, 'heartbeat');
     }
-    // debug('%s 💚 <-', self.client.clientId, error);
+    // logger.debug('%s 💚 <-', self.client.clientId, error);
   }
 
   const heartbeat = new Heartbeat(this.client, heartbeatCallback);
@@ -545,7 +545,7 @@ ConsumerGroup.prototype.close = function (force, cb) {
     function (callback) {
       self.leaveGroup(function (error) {
         if (error) {
-          debug('Leave group failed with', error);
+          logger.error('Leave group failed with', error);
         }
         callback(null);
       });

--- a/lib/consumerGroupHeartbeat.js
+++ b/lib/consumerGroupHeartbeat.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const HeartbeatTimeoutError = require('./errors/HeartbeatTimeoutError');
-const debug = require('debug')('kafka-node:ConsumerGroupHeartbeat');
+const logger = require('./logging')('kafka-node:ConsumerGroupHeartbeat');
 
 module.exports = class Heartbeat {
   constructor (client, handler) {
@@ -13,7 +13,7 @@ module.exports = class Heartbeat {
   send (groupId, generationId, memberId) {
     this.client.sendHeartbeatRequest(groupId, generationId, memberId, (error) => {
       if (this.canceled) {
-        debug('heartbeat yielded after being canceled', error);
+        logger.debug('heartbeat yielded after being canceled', error);
         return;
       }
       this.pending = false;

--- a/lib/consumerGroupMigrator.js
+++ b/lib/consumerGroupMigrator.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const util = require('util');
 const async = require('async');
-const debug = require('debug')('kafka-node:ConsumerGroupMigrator');
+const logger = require('./logging')('kafka-node:ConsumerGroupMigrator');
 const zookeeper = require('node-zookeeper-client');
 const _ = require('lodash');
 const EventEmitter = require('events').EventEmitter;
@@ -29,16 +29,16 @@ function ConsumerGroupMigrator (consumerGroup) {
         if (topics.length) {
           self.checkForOwnersAndListenForChange(topics);
         } else {
-          debug('No HLC topics exist in zookeeper.');
+          logger.debug('No HLC topics exist in zookeeper.');
           self.connectConsumerGroup();
         }
       });
     });
 
     this.on('noOwnersForTopics', function (topics) {
-      debug('No owners for topics %s reported.', topics);
+      logger.debug('No owners for topics %s reported.', topics);
       if (++verified <= NUMER_OF_TIMES_TO_VERIFY) {
-        debug('%s verify %d of %d HLC has given up ownership by checking again in %d', self.client.clientId, verified,
+        logger.debug('%s verify %d of %d HLC has given up ownership by checking again in %d', self.client.clientId, verified,
           NUMER_OF_TIMES_TO_VERIFY, VERIFY_WAIT_TIME_MS);
 
         setTimeout(function () {
@@ -63,7 +63,7 @@ function ConsumerGroupMigrator (consumerGroup) {
 util.inherits(ConsumerGroupMigrator, EventEmitter);
 
 ConsumerGroupMigrator.prototype.connectConsumerGroup = function () {
-  debug('%s connecting consumer group', this.client.clientId);
+  logger.debug('%s connecting consumer group', this.client.clientId);
   const self = this;
   if (this.client.ready) {
     this.consumerGroup.connect();
@@ -81,7 +81,7 @@ ConsumerGroupMigrator.prototype.filterByExistingZkTopics = function (callback) {
 
   async.filter(this.consumerGroup.topics, function (topic, cb) {
     const topicPath = path + topic;
-    debug('%s checking zk path %s', self.client.clientId, topicPath);
+    logger.debug('%s checking zk path %s', self.client.clientId, topicPath);
     self.zk.exists(topicPath, function (error, stat) {
       if (error) {
         return callback(error);
@@ -111,7 +111,7 @@ ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChan
       const args = [path + topic];
 
       if (listenForChange) {
-        debug('%s listening for changes in topic %s', self.client.clientId, topic);
+        logger.debug('%s listening for changes in topic %s', self.client.clientId, topic);
         args.push(topicWatcher);
       }
 
@@ -132,7 +132,7 @@ ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChan
       if (ownedPartitions === 0) {
         self.emit('noOwnersForTopics', topics);
       } else {
-        debug('%s %d partitions are owned by old HLC... waiting...', self.client.clientId, ownedPartitions);
+        logger.debug('%s %d partitions are owned by old HLC... waiting...', self.client.clientId, ownedPartitions);
       }
     }
   );
@@ -141,7 +141,7 @@ ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChan
 ConsumerGroupMigrator.prototype.saveHighLevelConsumerOffsets = function (topicPartitionList, callback) {
   const self = this;
   this.client.sendOffsetFetchRequest(this.consumerGroup.options.groupId, topicPartitionList, function (error, results) {
-    debug('sendOffsetFetchRequest response:', results, error);
+    logger.debug('sendOffsetFetchRequest response:', results, error);
     if (error) {
       return callback(error);
     }

--- a/lib/consumerGroupRecovery.js
+++ b/lib/consumerGroupRecovery.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const retry = require('retry');
-const debug = require('debug')('kafka-node:ConsumerGroupRecovery');
+const logger = require('./logging')('kafka-node:ConsumerGroupRecovery');
 const assert = require('assert');
 
 const GroupCoordinatorNotAvailable = require('./errors/GroupCoordinatorNotAvailableError');
@@ -60,7 +60,7 @@ ConsumerGroupRecovery.prototype.tryToRecoverFrom = function (error, source) {
   }
 
   if (retry && retryTimeout) {
-    debug('RECOVERY from %s: %s retrying in %s ms', source, this.consumerGroup.client.clientId, retryTimeout, error);
+    logger.debug('RECOVERY from %s: %s retrying in %s ms', source, this.consumerGroup.client.clientId, retryTimeout, error);
     this.consumerGroup.scheduleReconnect(retryTimeout);
   } else {
     this.consumerGroup.emit('error', error);

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -7,7 +7,7 @@ var uuid = require('uuid');
 var async = require('async');
 var errors = require('./errors');
 var retry = require('retry');
-var debug = require('debug')('kafka-node:HighLevelConsumer');
+var logger = require('./logging')('kafka-node:HighLevelConsumer');
 var validateConfig = require('./utils').validateConfig;
 
 var DEFAULTS = {
@@ -160,14 +160,14 @@ HighLevelConsumer.prototype.connect = function () {
   }
 
   function rebalance () {
-    debug('rebalance() %s is rebalancing: %s ready: %s', self.id, self.rebalancing, self.ready);
+    logger.debug('rebalance() %s is rebalancing: %s ready: %s', self.id, self.rebalancing, self.ready);
     if (!self.rebalancing && !self.closing) {
       deregister();
 
       self.emit('rebalancing');
 
       self.rebalancing = true;
-      debug('HighLevelConsumer rebalance retry config: %s', JSON.stringify(self.options.rebalanceRetry));
+      logger.debug('HighLevelConsumer rebalance retry config: %s', JSON.stringify(self.options.rebalanceRetry));
       var oldTopicPayloads = self.topicPayloads;
       var operation = retry.operation(self.options.rebalanceRetry);
 
@@ -216,14 +216,14 @@ HighLevelConsumer.prototype.connect = function () {
   this.on('registered', rebalance);
 
   function register (fn) {
-    debug('Registered listeners %s', self.id);
+    logger.debug('Registered listeners %s', self.id);
     self.client.zk.on('consumersChanged', fn || rebalance);
     self.client.zk.on('partitionsChanged', fn || rebalance);
     self.client.on('brokersChanged', fn || rebalance);
   }
 
   function deregister (fn) {
-    debug('Deregistered listeners %s', self.id);
+    logger.debug('Deregistered listeners %s', self.id);
     self.client.zk.removeListener('consumersChanged', fn || rebalance);
     self.client.zk.removeListener('partitionsChanged', fn || rebalance);
     self.client.removeListener('brokersChanged', fn || rebalance);
@@ -232,7 +232,7 @@ HighLevelConsumer.prototype.connect = function () {
   function pendingRebalance () {
     if (self.rebalancing) {
       self.pendingRebalances++;
-      debug('%s added a pendingRebalances %d', self.id, self.pendingRebalances);
+      logger.debug('%s added a pendingRebalances %d', self.id, self.pendingRebalances);
     }
   }
 
@@ -245,7 +245,7 @@ HighLevelConsumer.prototype.connect = function () {
   attachZookeeperErrorListener();
 
   this.client.on('zkReconnect', function () {
-    debug('zookeeper reconnect for %s', self.id);
+    logger.debug('zookeeper reconnect for %s', self.id);
     attachZookeeperErrorListener();
 
     // clean up what's leftover
@@ -263,9 +263,9 @@ HighLevelConsumer.prototype.connect = function () {
   this.on('rebalanced', function () {
     deregister(pendingRebalance);
     if (self.pendingRebalances && !self.closing) {
-      debug('%s pendingRebalances is %d scheduling a rebalance...', self.id, self.pendingRebalances);
+      logger.debug('%s pendingRebalances is %d scheduling a rebalance...', self.id, self.pendingRebalances);
       setTimeout(function () {
-        debug('%s running scheduled rebalance', self.id);
+        logger.debug('%s running scheduled rebalance', self.id);
         rebalance();
       }, 500);
     }
@@ -285,7 +285,7 @@ HighLevelConsumer.prototype.connect = function () {
   });
 
   this.client.on('close', function () {
-    debug('close');
+    logger.debug('close');
   });
 
   this.on('offsetOutOfRange', function (topic) {
@@ -353,12 +353,12 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
   // Do the rebalance.....
   var consumerPerTopicMap;
   var newTopicPayloads = [];
-  debug('HighLevelConsumer %s is attempting to rebalance', self.id);
+  logger.debug('HighLevelConsumer %s is attempting to rebalance', self.id);
   async.series([
 
     // Stop fetching data and commit offsets
     function (callback) {
-      debug('HighLevelConsumer %s stopping data read during rebalance', self.id);
+      logger.debug('HighLevelConsumer %s stopping data read during rebalance', self.id);
       self.stop(function () {
         callback();
       });
@@ -366,7 +366,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
     // Assemble the data
     function (callback) {
-      debug('HighLevelConsumer %s assembling data for rebalance', self.id);
+      logger.debug('HighLevelConsumer %s assembling data for rebalance', self.id);
       self.client.zk.getConsumersPerTopic(self.options.groupId, function (err, obj) {
         if (err) {
           callback(err);
@@ -379,14 +379,14 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
     // Release current partitions
     function (callback) {
-      debug('HighLevelConsumer %s releasing current partitions during rebalance', self.id);
+      logger.debug('HighLevelConsumer %s releasing current partitions during rebalance', self.id);
       self._releasePartitions(oldTopicPayloads, callback);
     },
 
     // Rebalance
     function (callback) {
-      debug('HighLevelConsumer %s determining the partitions to own during rebalance', self.id);
-      debug('consumerPerTopicMap.consumerTopicMap %j', consumerPerTopicMap.consumerTopicMap);
+      logger.debug('HighLevelConsumer %s determining the partitions to own during rebalance', self.id);
+      logger.debug('consumerPerTopicMap.consumerTopicMap %j', consumerPerTopicMap.consumerTopicMap);
       for (var topic in consumerPerTopicMap.consumerTopicMap[self.id]) {
         if (!consumerPerTopicMap.consumerTopicMap[self.id].hasOwnProperty(topic)) {
           continue;
@@ -423,14 +423,14 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
           });
         }
       }
-      debug('newTopicPayloads %j', newTopicPayloads);
+      logger.debug('newTopicPayloads %j', newTopicPayloads);
       callback();
     },
 
     // Update ZK with new ownership
     function (callback) {
       if (newTopicPayloads.length) {
-        debug('HighLevelConsumer %s gaining ownership of partitions during rebalance', self.id);
+        logger.debug('HighLevelConsumer %s gaining ownership of partitions during rebalance', self.id);
         async.eachSeries(newTopicPayloads, function (tp, cbb) {
           if (tp.partition !== undefined) {
             async.series([
@@ -465,7 +465,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
           }
         });
       } else {
-        debug('HighLevelConsumer %s has been assigned no partitions during rebalance', self.id);
+        logger.debug('HighLevelConsumer %s has been assigned no partitions during rebalance', self.id);
         callback();
       }
     },
@@ -477,10 +477,10 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     }],
     function (err) {
       if (err) {
-        debug('HighLevelConsumer %s rebalance attempt failed', self.id);
+        logger.debug('HighLevelConsumer %s rebalance attempt failed', self.id);
         cb(err);
       } else {
-        debug('HighLevelConsumer %s rebalance attempt was successful', self.id);
+        logger.debug('HighLevelConsumer %s rebalance attempt was successful', self.id);
         cb();
       }
     });
@@ -522,7 +522,7 @@ HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
 
   if (this.options.autoCommit && changed && !initing) {
     this.autoCommit(false, function (err) {
-      err && debug('auto commit offset', err);
+      err && logger.debug('auto commit offset', err);
     });
   }
 };
@@ -559,7 +559,7 @@ HighLevelConsumer.prototype.fetch = function () {
 };
 
 HighLevelConsumer.prototype.fetchOffset = function (payloads, cb) {
-  debug('in fetchOffset %s payloads: %j', this.id, payloads);
+  logger.debug('in fetchOffset %s payloads: %j', this.id, payloads);
   this.client.sendOffsetFetchRequest(this.options.groupId, payloads, cb);
 };
 

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const debug = require('debug');
+
+let loggerProvider = debugLoggerProvider;
+
+module.exports = exports = function getLogger (name) {
+  return loggerProvider(name);
+};
+
+exports.setLoggerProvider = function setLoggerProvider (provider) {
+  loggerProvider = provider;
+};
+
+function debugLoggerProvider (name) {
+  let logger = debug(name);
+  logger = logger.bind(logger);
+
+  return {
+    debug: logger,
+    info: logger,
+    warn: logger,
+    error: logger
+  };
+}

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -4,7 +4,7 @@ var zookeeper = require('node-zookeeper-client');
 var util = require('util');
 var async = require('async');
 var EventEmiter = require('events').EventEmitter;
-var debug = require('debug')('kafka-node:zookeeper');
+var logger = require('./logging')('kafka-node:zookeeper');
 
 /**
  * Provides kafka specific helpers for talking with zookeeper
@@ -32,7 +32,7 @@ util.inherits(Zookeeper, EventEmiter);
 Zookeeper.prototype.unregisterConsumer = function (groupId, consumerId, cb) {
   var path = '/consumers/' + groupId + '/ids/' + consumerId;
   var self = this;
-  debug('unregister consumer node: %s', path);
+  logger.debug('unregister consumer node: %s', path);
   async.waterfall([
     function (callback) {
       self.client.exists(path, callback);
@@ -41,7 +41,7 @@ Zookeeper.prototype.unregisterConsumer = function (groupId, consumerId, cb) {
       if (stat) {
         self.client.remove(path, function (error) {
           if (error) {
-            debug(error);
+            logger.error(error);
             return callback(error);
           }
           callback(null, true);
@@ -105,7 +105,7 @@ Zookeeper.prototype.registerConsumer = function (groupId, consumerId, payloads, 
         if (error) {
           callback(error);
         } else {
-          debug('Node: %s was created.', path + '/ids/' + consumerId);
+          logger.debug('Node: %s was created.', path + '/ids/' + consumerId);
           cb();
         }
       });
@@ -129,7 +129,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
           callback(error);
           return;
         } else {
-          debug('Children are: %j.', children);
+          logger.debug('Children are: %j.', children);
           async.each(children, function (consumer, cbb) {
             var path = consumersPath + '/' + consumer;
             that.client.getData(
@@ -158,7 +158,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
 
                     cbb();
                   } catch (e) {
-                    debug(e);
+                    logger.error(e);
                     cbb(new Error('Unable to assemble data'));
                   }
                 }
@@ -209,7 +209,7 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
     }],
     function (err) {
       if (err) {
-        debug(err);
+        logger.debug(err);
         cb(err);
       } else cb(null, consumerPerTopicMap);
     });
@@ -231,7 +231,7 @@ Zookeeper.prototype.listPartitions = function (topic) {
     },
     function (error, children) {
       if (error) {
-        debug(error);
+        logger.error(error);
         // Ignore NO_NODE error here #157
         if (error.name !== 'NO_NODE') {
           self.emit('error', error);
@@ -256,7 +256,7 @@ Zookeeper.prototype.listBrokers = function (cb) {
     },
     function (error, children) {
       if (error) {
-        debug('Failed to list children of node: %s due to: %s.', path, error);
+        logger.debug('Failed to list children of node: %s due to: %s.', path, error);
         that.emit('error', error);
         return;
       }
@@ -318,7 +318,7 @@ Zookeeper.prototype.listConsumers = function (groupId) {
     },
     function (error, children) {
       if (error) {
-        debug(error);
+        logger.error(error);
         // Ignore NO_NODE error here #157
         if (error.name !== 'NO_NODE') {
           that.emit('error', error);
@@ -339,7 +339,7 @@ Zookeeper.prototype.topicExists = function (topic, cb, watch) {
   this.client.exists(
     path,
     function (event) {
-      debug('Got event: %s.', event);
+      logger.debug('Got event: %s.', event);
       if (watch) {
         self.topicExists(topic, cb);
       }
@@ -359,7 +359,7 @@ Zookeeper.prototype.deletePartitionOwnership = function (groupId, topic, partiti
       if (error) {
         cb(error);
       } else {
-        debug('Removed partition ownership %s', path);
+        logger.debug('Removed partition ownership %s', path);
         cb();
       }
     }
@@ -414,7 +414,7 @@ Zookeeper.prototype.addPartitionOwnership = function (consumerId, groupId, topic
         if (error) {
           callback(error);
         } else if (stat) {
-          debug('Gained ownership of %s by %s.', path, consumerId);
+          logger.debug('Gained ownership of %s by %s.', path, consumerId);
           callback();
         } else {
           callback("Path wasn't created");

--- a/logging.js
+++ b/logging.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const logging = require('./lib/logging');
+
+exports.setLoggerProvider = logging.setLoggerProvider;

--- a/test/test.logging.js
+++ b/test/test.logging.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const createLogger = require('../lib/logging');
+const logging = require('../logging');
+const sinon = require('sinon');
+
+describe('logging', function () {
+  it('should expose a setLoggerProvider function', function () {
+    logging.setLoggerProvider.should.be.instanceOf(Function);
+  });
+
+  it('should create logger via custom logger provider', function () {
+    const provider = sinon.stub();
+    const loggerName = 'kafka-node:consumer';
+    const loggerImpl = {};
+    provider.withArgs(loggerName).returns(loggerImpl);
+    logging.setLoggerProvider(provider);
+
+    const logger = createLogger(loggerName);
+
+    logger.should.equal(loggerImpl);
+  });
+});


### PR DESCRIPTION
Kafka-node should be easier to integrate into larger applications. A
large part of this is log handling. Debug's log output configuration is
not really usable for application developers and does not allow
filtering of log messages by level.

This PR adds the ability to set logger providers while retaining the
current default logging strategy: debug.

Fixes #595