### PR TITLE
Dependencies should be checked for security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "istanbul": "^0.4.4",
     "mocha": "^3.1.0",
+    "nsp": "^2.6.2",
     "optimist": "^0.6.1",
     "proxyquire": "^1.7.10",
     "should": "^6.0.0",
@@ -53,7 +54,7 @@
     "url": "https://github.com/SOHU-Co/kafka-node.git"
   },
   "scripts": {
-    "test": "eslint . && ./run-tests.sh",
+    "test": "eslint . && ./run-tests.sh && nsp check",
     "startDocker": "./start-docker.sh",
     "stopDocker": "docker-compose down",
     "updateToc": "doctoc README.md --maxlevel 2 --notitle"


### PR DESCRIPTION
Dependencies should frequently be checked for security vulnerabilities as part of the build job. This commit adds the Node Security Platform CLI tool (`nsp`) to the build process. Dependency verification is really fast, so it is not slowing down the build / local tests.

Also, there are currently no known vulnerabilities 🍹 