### PR TITLE
fix : createTopics can not get a number for topics parameter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -353,7 +353,7 @@ Client.prototype.loadMetadataForTopics = function (topics, cb) {
 };
 
 Client.prototype.createTopics = function (topics, isAsync, cb) {
-  topics = typeof topics === 'string' ? [topics] : topics;
+  topics = _.includes(['string', 'number'], typeof topics) ? [String(topics)] : topics;
 
   if (typeof isAsync === 'function' && typeof cb === 'undefined') {
     cb = isAsync;


### PR DESCRIPTION
When `createTopics(topics,async, cb)` function get a number topics .
It broken my node program. So I think it's better to resolve this situation by check the type of `topics` parameters