### PR TITLE
Improve performance

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,6 @@ var async = require('async');
 var retry = require('retry');
 var events = require('events');
 var errors = require('./errors');
-var Binary = require('binary');
 var getCodec = require('./codec');
 var protocol = require('./protocol');
 var BrokerWrapper = require('./wrapper/BrokerWrapper');
@@ -21,6 +20,7 @@ var url = require('url');
 var logger = require('./logging')('kafka-node:Client');
 var validateConfig = require('./utils').validateConfig;
 var validateKafkaTopics = require('./utils').validateTopicNames;
+var BufferList = require('bl');
 
 const MAX_INT32 = 2147483647;
 
@@ -694,10 +694,10 @@ Client.prototype.createBroker = function (host, port, longpolling) {
   socket.on('end', function () {
     retry(this);
   });
-  socket.buffer = new Buffer([]);
+  socket.buffer = new BufferList();
   socket.on('data', function (data) {
-    this.buffer = Buffer.concat([this.buffer, data]);
-    self.handleReceivedData(this);
+    socket.buffer.append(data);
+    self.handleReceivedData(socket);
   });
   socket.setKeepAlive(true, 60000);
 
@@ -723,22 +723,22 @@ Client.prototype.reconnectBroker = function (oldSocket) {
 };
 
 Client.prototype.handleReceivedData = function (socket) {
-  var vars = Binary.parse(socket.buffer).word32bu('size').word32bu('correlationId').vars;
-  var size = vars.size + 4;
-  var correlationId = vars.correlationId;
+  const {buffer} = socket;
+  const size = buffer.readUInt32BE(0) + 4;
 
-  if (socket.buffer.length >= size) {
-    var resp = socket.buffer.slice(0, size);
-    var handlers = this.unqueueCallback(socket, correlationId);
+  if (buffer.length >= size) {
+    const resp = buffer.shallowSlice(0, size);
+    const correlationId = resp.readUInt32BE(4);
+    const handlers = this.unqueueCallback(socket, correlationId);
 
     if (!handlers) return;
-    var decoder = handlers[0];
-    var cb = handlers[1];
-    var result = decoder(resp);
+    const decoder = handlers[0];
+    const cb = handlers[1];
+    const result = decoder(resp);
     (result instanceof Error)
       ? cb.call(this, result)
       : cb.call(this, null, result);
-    socket.buffer = socket.buffer.slice(size);
+    buffer.consume(size);
     if (socket.longpolling) socket.waiting = false;
   } else { return; }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -723,18 +723,18 @@ Client.prototype.reconnectBroker = function (oldSocket) {
 };
 
 Client.prototype.handleReceivedData = function (socket) {
-  const {buffer} = socket;
-  const size = buffer.readUInt32BE(0) + 4;
+  var buffer = socket.buffer;
+  var size = buffer.readUInt32BE(0) + 4;
 
   if (buffer.length >= size) {
-    const resp = buffer.shallowSlice(0, size);
-    const correlationId = resp.readUInt32BE(4);
-    const handlers = this.unqueueCallback(socket, correlationId);
+    var resp = buffer.shallowSlice(0, size);
+    var correlationId = resp.readUInt32BE(4);
+    var handlers = this.unqueueCallback(socket, correlationId);
 
     if (!handlers) return;
-    const decoder = handlers[0];
-    const cb = handlers[1];
-    const result = decoder(resp);
+    var decoder = handlers[0];
+    var cb = handlers[1];
+    var result = decoder(resp);
     (result instanceof Error)
       ? cb.call(this, result)
       : cb.call(this, null, result);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "producer",
     "broker"
   ],
-  "files": ["kafka.js", "logging.js", "lib"],
+  "files": [
+    "kafka.js",
+    "logging.js",
+    "lib"
+  ],
   "bugs": "https://github.com/SOHU-co/kafka-node/issues",
   "version": "1.6.0",
   "main": "kafka.js",
@@ -16,6 +20,7 @@
   "dependencies": {
     "async": ">0.9 <2.0",
     "binary": "~0.3.0",
+    "bl": "^1.2.0",
     "buffer-crc32": "~0.2.5",
     "buffermaker": "~1.2.0",
     "debug": "^2.1.3",

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -13,6 +13,7 @@ if [ -z "$TRAVIS" ]; then
         DOCKER_VM_IP=`dlite ip`
     fi
 
+    DOCKER_VM_IP=${DOCKER_VM_IP:-127.0.0.1}
     export KAFKA_ADVERTISED_HOST_NAME=$DOCKER_VM_IP
     docker-compose down
     docker-compose up -d


### PR DESCRIPTION
`Buffer#slice()` in node is extremely slow and should avoid using it! Unfortunately, we didn't realize it when create this project. So, we should have a plan to improve the performance of this module:

- Step 1: Using `BufferList`(bl) instead of raw Buffer to avoid calling `Buffer#slice()`.
  I have a patch for this module, and tested it in production. In my case, I have reduced CPU usage from **70%** to **50%**, and memory usage from **400m** to **200m**, and increased throughput from **200k/min** to **400k/min**. 
- Step 2: Replace `binary` module. The module is 5 years old and have not be maintained for 5 years! `kafka-node` is heavily depended on `binary` but unfortunately `binary` used `Buffer#slice()`, a lot.

This patch complete `Step 1`,  and I hope someone else could help me with the `Step 2`.