### PR TITLE
Check buffer length before processing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -725,7 +725,7 @@ Client.prototype.reconnectBroker = function (oldSocket) {
 Client.prototype.handleReceivedData = function (socket) {
   var buffer = socket.buffer;
   if (!buffer.length) {
-    return
+    return;
   }
   var size = buffer.readUInt32BE(0) + 4;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -724,6 +724,9 @@ Client.prototype.reconnectBroker = function (oldSocket) {
 
 Client.prototype.handleReceivedData = function (socket) {
   var buffer = socket.buffer;
+  if (!buffer.length) {
+    return
+  }
   var size = buffer.readUInt32BE(0) + 4;
 
   if (buffer.length >= size) {


### PR DESCRIPTION
Found a bug on data handling. Buffer could be empty between new incoming data arrived and `setImmediate()` callback be called