### PR TITLE
Node Ecmascript 5 runtime compatibility

### DIFF
--- a/lib/assignment/range.js
+++ b/lib/assignment/range.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const logger = require('../logging')('kafka-node:Range');
-const VERSION = 0;
-const _ = require('lodash');
-const groupPartitionsByTopic = require('../utils').groupPartitionsByTopic;
+var logger = require('../logging')('kafka-node:Range');
+var VERSION = 0;
+var _ = require('lodash');
+var groupPartitionsByTopic = require('../utils').groupPartitionsByTopic;
 
 function assignRange (topicPartition, groupMembers, callback) {
   logger.debug('topicPartition: %j', topicPartition);
@@ -12,7 +12,7 @@ function assignRange (topicPartition, groupMembers, callback) {
     return obj;
   }, {});
 
-  const topicMemberMap = topicToMemberMap(groupMembers);
+  var topicMemberMap = topicToMemberMap(groupMembers);
   for (var topic in topicMemberMap) {
     if (!topicMemberMap.hasOwnProperty(topic)) {
       continue;

--- a/lib/baseProducer.js
+++ b/lib/baseProducer.js
@@ -93,7 +93,7 @@ BaseProducer.prototype.connect = function () {
     }
   });
   this.client.on('brokersChanged', function () {
-    let topics = Object.keys(this.topicMetadata);
+    var topics = Object.keys(this.topicMetadata);
     this.refreshMetadata(topics, function (error) {
       if (error) {
         self.emit('error', error);
@@ -124,11 +124,11 @@ BaseProducer.prototype.send = function (payloads, cb) {
 };
 
 BaseProducer.prototype.buildPayloads = function (payloads, topicMetadata) {
-  const topicPartitionRequests = Object.create(null);
+  var topicPartitionRequests = Object.create(null);
   payloads.forEach((p) => {
     p.partition = p.hasOwnProperty('partition') ? p.partition : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.key);
     p.attributes = p.hasOwnProperty('attributes') ? p.attributes : 0;
-    let messages = _.isArray(p.messages) ? p.messages : [p.messages];
+    var messages = _.isArray(p.messages) ? p.messages : [p.messages];
 
     messages = messages.map(function (message) {
       if (message instanceof KeyedMessage) {
@@ -137,8 +137,8 @@ BaseProducer.prototype.buildPayloads = function (payloads, topicMetadata) {
       return new Message(0, 0, '', message);
     });
 
-    let key = p.topic + p.partition;
-    let request = topicPartitionRequests[key];
+    var key = p.topic + p.partition;
+    var request = topicPartitionRequests[key];
 
     if (request == null) {
       topicPartitionRequests[key] = new ProduceRequest(p.topic, p.partition, messages, p.attributes);

--- a/lib/baseProducer.js
+++ b/lib/baseProducer.js
@@ -125,7 +125,7 @@ BaseProducer.prototype.send = function (payloads, cb) {
 
 BaseProducer.prototype.buildPayloads = function (payloads, topicMetadata) {
   var topicPartitionRequests = Object.create(null);
-  payloads.forEach((p) => {
+  payloads.forEach(function (p) {
     p.partition = p.hasOwnProperty('partition') ? p.partition : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.key);
     p.attributes = p.hasOwnProperty('attributes') ? p.attributes : 0;
     var messages = _.isArray(p.messages) ? p.messages : [p.messages];

--- a/lib/client.js
+++ b/lib/client.js
@@ -22,7 +22,7 @@ var validateConfig = require('./utils').validateConfig;
 var validateKafkaTopics = require('./utils').validateTopicNames;
 var BufferList = require('bl');
 
-const MAX_INT32 = 2147483647;
+var MAX_INT32 = 2147483647;
 
 /**
  * Communicates with kafka brokers
@@ -369,7 +369,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
 
   cb = _.once(cb);
 
-  const getTopicsFromKafka = (topics, callback) => {
+  var getTopicsFromKafka = (topics, callback) => {
     this.loadMetadataForTopics(topics, function (error, resp) {
       if (error) {
         return callback(error);
@@ -378,7 +378,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
     });
   };
 
-  const operation = retry.operation({ minTimeout: 200, maxTimeout: 2000 });
+  var operation = retry.operation({ minTimeout: 200, maxTimeout: 2000 });
 
   operation.attempt(currentAttempt => {
     logger.debug('create topics currentAttempt', currentAttempt);
@@ -390,7 +390,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
       }
 
       logger.debug('kafka reported topics', kafkaTopics);
-      const left = _.difference(topics, kafkaTopics);
+      var left = _.difference(topics, kafkaTopics);
       if (left.length === 0) {
         logger.debug(`Topics created ${kafkaTopics}`);
         return cb(null, kafkaTopics);

--- a/lib/client.js
+++ b/lib/client.js
@@ -369,7 +369,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
 
   cb = _.once(cb);
 
-  var getTopicsFromKafka = (topics, callback) => {
+  var getTopicsFromKafka = function (topics, callback) {
     this.loadMetadataForTopics(topics, function (error, resp) {
       if (error) {
         return callback(error);
@@ -380,7 +380,7 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
 
   var operation = retry.operation({ minTimeout: 200, maxTimeout: 2000 });
 
-  operation.attempt(currentAttempt => {
+  operation.attempt(function (currentAttempt) {
     logger.debug('create topics currentAttempt', currentAttempt);
     getTopicsFromKafka(topics, function (error, kafkaTopics) {
       if (error) {
@@ -389,15 +389,15 @@ Client.prototype.createTopics = function (topics, isAsync, cb) {
         }
       }
 
-      logger.debug('kafka reported topics', kafkaTopics);
+      logger.debug('kafka reported topics ', kafkaTopics);
       var left = _.difference(topics, kafkaTopics);
       if (left.length === 0) {
-        logger.debug(`Topics created ${kafkaTopics}`);
+        logger.debug('Topics created '+ kafkaTopics);
         return cb(null, kafkaTopics);
       }
 
-      logger.debug(`Topics left ${left.join(', ')}`);
-      if (!operation.retry(new Error(`Topics not created ${left}`))) {
+      logger.debug('Topics left ' + left.join(', '));
+      if (!operation.retry(new Error('Topics not created ' + left ))) {
         cb(operation.mainError());
       }
     });

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -63,11 +63,11 @@ function ConsumerGroup (memberOptions, topics) {
   }
 
   if (!(this.options.fromOffset in ACCEPTED_FROM_OFFSET)) {
-    throw new Error(`fromOffset ${this.options.fromOffset} should be either: ${Object.keys(ACCEPTED_FROM_OFFSET).join(', ')}`);
+    throw new Error('fromOffset ' + this.options.fromOffset + ' should be either: ' + Object.keys(ACCEPTED_FROM_OFFSET).join(', ') + '');
   }
 
   if (!(this.options.outOfRangeOffset in ACCEPTED_FROM_OFFSET)) {
-    throw new Error(`outOfRangeOffset ${this.options.outOfRangeOffset} should be either: ${Object.keys(ACCEPTED_FROM_OFFSET).join(', ')}`);
+    throw new Error('outOfRangeOffset ' + this.options.outOfRangeOffset + ' should be either: ' + Object.keys(ACCEPTED_FROM_OFFSET).join(', ') + '');
   }
 
   this.client = new Client(memberOptions.host, memberOptions.id, memberOptions.zk,
@@ -132,18 +132,18 @@ function ConsumerGroup (memberOptions, topics) {
     self.fetch();
   });
 
-  this.on('offsetOutOfRange', topic => {
+  this.on('offsetOutOfRange', function (topic) {
     this.pause();
     if (this.options.outOfRangeOffset === 'none') {
-      this.emit('error', new errors.InvalidConsumerOffsetError(`Offset out of range for topic "${topic.topic}" partition ${topic.partition}`));
+      this.emit('error', new errors.InvalidConsumerOffsetError('Offset out of range for topic "' + topic.topic + '" partition ' + topic.partition + ''));
       return;
     }
 
     topic.time = ACCEPTED_FROM_OFFSET[this.options.outOfRangeOffset];
 
-    this.getOffset().fetch([topic], (error, result) => {
+    this.getOffset().fetch([topic], function (error, result) {
       if (error) {
-        this.emit('error', new errors.InvalidConsumerOffsetError(`Fetching ${this.options.outOfRangeOffset} offset failed`, error));
+        this.emit('error', new errors.InvalidConsumerOffsetError('Fetching '+this.options.outOfRangeOffset+' offset failed', error));
         return;
       }
       var offset = _.head(result[topic.topic][topic.partition]);
@@ -254,7 +254,7 @@ ConsumerGroup.prototype.handleJoinGroup = function (joinGroupResponse, callback)
 
 ConsumerGroup.prototype.saveDefaultOffsets = function (topicPartitionList, callback) {
   var self = this;
-  var offsetPayload = _(topicPartitionList).cloneDeep().map(tp => {
+  var offsetPayload = _(topicPartitionList).cloneDeep().map(function (tp) {
     tp.time = ACCEPTED_FROM_OFFSET[this.options.fromOffset];
     return tp;
   });
@@ -295,7 +295,7 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
           logger.debug('No saved offsets');
 
           if (self.options.fromOffset === 'none') {
-            return callback(new Error(`${self.client.clientId} owns topics and partitions which contains no saved offsets for group '${self.options.groupId}'`));
+            return callback(new Error(self.client.clientId + ' owns topics and partitions which contains no saved offsets for group "'+ self.options.groupId + '" '));
           }
 
           async.parallel([
@@ -448,7 +448,7 @@ ConsumerGroup.prototype.startHeartbeats = function () {
 
   var heartbeat = this.sendHeartbeat();
 
-  this.heartbeatInterval = setInterval(() => {
+  this.heartbeatInterval = setInterval(function () {
     // only send another heartbeat if we got a response from the last one
     if (heartbeat.verifyResolved()) {
       heartbeat = this.sendHeartbeat();

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -1,31 +1,31 @@
 'use strict';
 
-const logger = require('./logging')('kafka-node:ConsumerGroup');
-const util = require('util');
-const EventEmitter = require('events');
-const highLevelConsumer = require('./highLevelConsumer');
-const Client = require('./client');
-const Offset = require('./offset');
-const _ = require('lodash');
-const async = require('async');
-const validateConfig = require('./utils').validateConfig;
-const ConsumerGroupRecovery = require('./consumerGroupRecovery');
-const Heartbeat = require('./consumerGroupHeartbeat');
-const createTopicPartitionList = require('./utils').createTopicPartitionList;
-const errors = require('./errors');
+var logger = require('./logging')('kafka-node:ConsumerGroup');
+var util = require('util');
+var EventEmitter = require('events');
+var highLevelConsumer = require('./highLevelConsumer');
+var Client = require('./client');
+var Offset = require('./offset');
+var _ = require('lodash');
+var async = require('async');
+var validateConfig = require('./utils').validateConfig;
+var ConsumerGroupRecovery = require('./consumerGroupRecovery');
+var Heartbeat = require('./consumerGroupHeartbeat');
+var createTopicPartitionList = require('./utils').createTopicPartitionList;
+var errors = require('./errors');
 
-const assert = require('assert');
-const builtInProtocols = require('./assignment');
+var assert = require('assert');
+var builtInProtocols = require('./assignment');
 
-const LATEST_OFFSET = -1;
-const EARLIEST_OFFSET = -2;
-const ACCEPTED_FROM_OFFSET = {
+var LATEST_OFFSET = -1;
+var EARLIEST_OFFSET = -2;
+var ACCEPTED_FROM_OFFSET = {
   latest: LATEST_OFFSET,
   earliest: EARLIEST_OFFSET,
   none: false
 };
 
-const DEFAULTS = {
+var DEFAULTS = {
   groupId: 'kafka-node-group',
   // Auto commit config
   autoCommit: true,
@@ -51,7 +51,7 @@ const DEFAULTS = {
 
 function ConsumerGroup (memberOptions, topics) {
   EventEmitter.call(this);
-  const self = this;
+  var self = this;
   this.options = _.defaults((memberOptions || {}), DEFAULTS);
 
   if (!this.options.heartbeatInterval) {
@@ -90,7 +90,7 @@ function ConsumerGroup (memberOptions, topics) {
   }
 
   if (this.options.migrateHLC) {
-    const ConsumerGroupMigrator = require('./consumerGroupMigrator');
+    var ConsumerGroupMigrator = require('./consumerGroupMigrator');
     this.migrator = new ConsumerGroupMigrator(this);
     this.migrator.on('error', function (error) {
       self.emit('error', error);
@@ -102,7 +102,7 @@ function ConsumerGroup (memberOptions, topics) {
     self.emit('error', err);
   });
 
-  const recoverFromBrokerChange = _.debounce(function () {
+  var recoverFromBrokerChange = _.debounce(function () {
     logger.debug('brokersChanged refreshing metadata');
     self.client.refreshMetadata(self.topics, function (error) {
       if (error) {
@@ -146,8 +146,8 @@ function ConsumerGroup (memberOptions, topics) {
         this.emit('error', new errors.InvalidConsumerOffsetError(`Fetching ${this.options.outOfRangeOffset} offset failed`, error));
         return;
       }
-      const offset = _.head(result[topic.topic][topic.partition]);
-      const oldOffset = _.find(this.topicPayloads, {topic: topic.topic, partition: topic.partition}).offset;
+      var offset = _.head(result[topic.topic][topic.partition]);
+      var oldOffset = _.find(this.topicPayloads, {topic: topic.topic, partition: topic.partition}).offset;
 
       logger.debug('replacing %s-%s stale offset of %d with %d', topic.topic, topic.partition, oldOffset, offset);
 
@@ -254,7 +254,7 @@ ConsumerGroup.prototype.handleJoinGroup = function (joinGroupResponse, callback)
 
 ConsumerGroup.prototype.saveDefaultOffsets = function (topicPartitionList, callback) {
   var self = this;
-  const offsetPayload = _(topicPartitionList).cloneDeep().map(tp => {
+  var offsetPayload = _(topicPartitionList).cloneDeep().map(tp => {
     tp.time = ACCEPTED_FROM_OFFSET[this.options.fromOffset];
     return tp;
   });
@@ -277,8 +277,8 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
   if (ownedTopics.length) {
     logger.debug('%s owns topics: ', self.client.clientId, syncGroupResponse.partitions);
 
-    const topicPartitionList = createTopicPartitionList(syncGroupResponse.partitions);
-    const useDefaultOffsets = self.options.fromOffset in ACCEPTED_FROM_OFFSET;
+    var topicPartitionList = createTopicPartitionList(syncGroupResponse.partitions);
+    var useDefaultOffsets = self.options.fromOffset in ACCEPTED_FROM_OFFSET;
 
     async.waterfall([
       function (callback) {
@@ -441,12 +441,12 @@ ConsumerGroup.prototype.startHeartbeats = function () {
   assert(this.options.sessionTimeout > 0);
   assert(this.ready, 'consumerGroup is not ready');
 
-  const heartbeatIntervalMs = this.options.heartbeatInterval || (Math.floor(this.options.sessionTimeout / 3));
+  var heartbeatIntervalMs = this.options.heartbeatInterval || (Math.floor(this.options.sessionTimeout / 3));
 
   logger.debug('%s started heartbeats at every %d ms', this.client.clientId, heartbeatIntervalMs);
   this.stopHeartbeats();
 
-  let heartbeat = this.sendHeartbeat();
+  var heartbeat = this.sendHeartbeat();
 
   this.heartbeatInterval = setInterval(() => {
     // only send another heartbeat if we got a response from the last one
@@ -488,7 +488,7 @@ ConsumerGroup.prototype.sendHeartbeat = function () {
     // logger.debug('%s 💚 <-', self.client.clientId, error);
   }
 
-  const heartbeat = new Heartbeat(this.client, heartbeatCallback);
+  var heartbeat = new Heartbeat(this.client, heartbeatCallback);
   heartbeat.send(this.options.groupId, this.generationId, this.memberId);
 
   return heartbeat;

--- a/lib/consumerGroupHeartbeat.js
+++ b/lib/consumerGroupHeartbeat.js
@@ -3,15 +3,17 @@
 var HeartbeatTimeoutError = require('./errors/HeartbeatTimeoutError');
 var logger = require('./logging')('kafka-node:ConsumerGroupHeartbeat');
 
-module.exports = class Heartbeat {
-  constructor (client, handler) {
+//module.exports = class Heartbeat {
+//  constructor (client, handler) {
+  
+function  Heartbeat (client, handler) {
     this.client = client;
     this.handler = handler;
     this.pending = true;
   }
 
-  send (groupId, generationId, memberId) {
-    this.client.sendHeartbeatRequest(groupId, generationId, memberId, (error) => {
+Heartbeat.prototype.send = function (groupId, generationId, memberId) {
+    this.client.sendHeartbeatRequest(groupId, generationId, memberId, function (error) {
       if (this.canceled) {
         logger.debug('heartbeat yielded after being canceled', error);
         return;
@@ -21,7 +23,7 @@ module.exports = class Heartbeat {
     });
   }
 
-  verifyResolved () {
+Heartbeat.prototype.verifyResolved = function () {
     if (this.pending) {
       this.canceled = true;
       this.pending = false;
@@ -30,4 +32,5 @@ module.exports = class Heartbeat {
     }
     return true;
   }
-};
+// };
+module.exports = Heartbeat;

--- a/lib/consumerGroupHeartbeat.js
+++ b/lib/consumerGroupHeartbeat.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const HeartbeatTimeoutError = require('./errors/HeartbeatTimeoutError');
-const logger = require('./logging')('kafka-node:ConsumerGroupHeartbeat');
+var HeartbeatTimeoutError = require('./errors/HeartbeatTimeoutError');
+var logger = require('./logging')('kafka-node:ConsumerGroupHeartbeat');
 
 module.exports = class Heartbeat {
   constructor (client, handler) {

--- a/lib/consumerGroupMigrator.js
+++ b/lib/consumerGroupMigrator.js
@@ -1,19 +1,19 @@
 'use strict';
 
-const assert = require('assert');
-const util = require('util');
-const async = require('async');
-const logger = require('./logging')('kafka-node:ConsumerGroupMigrator');
-const zookeeper = require('node-zookeeper-client');
-const _ = require('lodash');
-const EventEmitter = require('events').EventEmitter;
-const NUMER_OF_TIMES_TO_VERIFY = 4;
-const VERIFY_WAIT_TIME_MS = 1500;
+var assert = require('assert');
+var util = require('util');
+var async = require('async');
+var logger = require('./logging')('kafka-node:ConsumerGroupMigrator');
+var zookeeper = require('node-zookeeper-client');
+var _ = require('lodash');
+var EventEmitter = require('events').EventEmitter;
+var NUMER_OF_TIMES_TO_VERIFY = 4;
+var VERIFY_WAIT_TIME_MS = 1500;
 
 function ConsumerGroupMigrator (consumerGroup) {
   EventEmitter.call(this);
   assert(consumerGroup);
-  const self = this;
+  var self = this;
   this.consumerGroup = consumerGroup;
   this.client = consumerGroup.client;
   var verified = 0;
@@ -64,7 +64,7 @@ util.inherits(ConsumerGroupMigrator, EventEmitter);
 
 ConsumerGroupMigrator.prototype.connectConsumerGroup = function () {
   logger.debug('%s connecting consumer group', this.client.clientId);
-  const self = this;
+  var self = this;
   if (this.client.ready) {
     this.consumerGroup.connect();
   } else {
@@ -76,11 +76,11 @@ ConsumerGroupMigrator.prototype.connectConsumerGroup = function () {
 };
 
 ConsumerGroupMigrator.prototype.filterByExistingZkTopics = function (callback) {
-  const self = this;
-  const path = '/consumers/' + this.consumerGroup.options.groupId + '/owners/';
+  var self = this;
+  var path = '/consumers/' + this.consumerGroup.options.groupId + '/owners/';
 
   async.filter(this.consumerGroup.topics, function (topic, cb) {
-    const topicPath = path + topic;
+    var topicPath = path + topic;
     logger.debug('%s checking zk path %s', self.client.clientId, topicPath);
     self.zk.exists(topicPath, function (error, stat) {
       if (error) {
@@ -98,8 +98,8 @@ ConsumerGroupMigrator.prototype.checkForOwnersAndListenForChange = function (top
 };
 
 ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChange) {
-  const self = this;
-  const path = '/consumers/' + this.consumerGroup.options.groupId + '/owners/';
+  var self = this;
+  var path = '/consumers/' + this.consumerGroup.options.groupId + '/owners/';
   var ownedPartitions = 0;
 
   function topicWatcher (event) {
@@ -108,7 +108,7 @@ ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChan
 
   async.each(topics,
     function (topic, callback) {
-      const args = [path + topic];
+      var args = [path + topic];
 
       if (listenForChange) {
         logger.debug('%s listening for changes in topic %s', self.client.clientId, topic);
@@ -139,7 +139,7 @@ ConsumerGroupMigrator.prototype.checkForOwners = function (topics, listenForChan
 };
 
 ConsumerGroupMigrator.prototype.saveHighLevelConsumerOffsets = function (topicPartitionList, callback) {
-  const self = this;
+  var self = this;
   this.client.sendOffsetFetchRequest(this.consumerGroup.options.groupId, topicPartitionList, function (error, results) {
     logger.debug('sendOffsetFetchRequest response:', results, error);
     if (error) {
@@ -151,7 +151,7 @@ ConsumerGroupMigrator.prototype.saveHighLevelConsumerOffsets = function (topicPa
 };
 
 ConsumerGroupMigrator.prototype.getOffset = function (tp, defaultOffset) {
-  const offset = _.get(this.offsets, [tp.topic, tp.partition], defaultOffset);
+  var offset = _.get(this.offsets, [tp.topic, tp.partition], defaultOffset);
   if (offset === -1) {
     return defaultOffset;
   }

--- a/lib/consumerGroupRecovery.js
+++ b/lib/consumerGroupRecovery.js
@@ -1,19 +1,19 @@
 'use strict';
 
-const retry = require('retry');
-const logger = require('./logging')('kafka-node:ConsumerGroupRecovery');
-const assert = require('assert');
+var retry = require('retry');
+var logger = require('./logging')('kafka-node:ConsumerGroupRecovery');
+var assert = require('assert');
 
-const GroupCoordinatorNotAvailable = require('./errors/GroupCoordinatorNotAvailableError');
-const NotCoordinatorForGroup = require('./errors/NotCoordinatorForGroupError');
-const IllegalGeneration = require('./errors/IllegalGenerationError');
-const GroupLoadInProgress = require('./errors/GroupLoadInProgressError');
-const UnknownMemberId = require('./errors/UnknownMemberIdError');
-const RebalanceInProgress = require('./errors/RebalanceInProgressError');
-const HeartbeatTimeout = require('./errors/HeartbeatTimeoutError');
-const BrokerNotAvailableError = require('./errors').BrokerNotAvailableError;
+var GroupCoordinatorNotAvailable = require('./errors/GroupCoordinatorNotAvailableError');
+var NotCoordinatorForGroup = require('./errors/NotCoordinatorForGroupError');
+var IllegalGeneration = require('./errors/IllegalGenerationError');
+var GroupLoadInProgress = require('./errors/GroupLoadInProgressError');
+var UnknownMemberId = require('./errors/UnknownMemberIdError');
+var RebalanceInProgress = require('./errors/RebalanceInProgressError');
+var HeartbeatTimeout = require('./errors/HeartbeatTimeoutError');
+var BrokerNotAvailableError = require('./errors').BrokerNotAvailableError;
 
-const recoverableErrors = [
+var recoverableErrors = [
   {
     errors: [GroupCoordinatorNotAvailable, IllegalGeneration, GroupLoadInProgress, RebalanceInProgress, HeartbeatTimeout]
   },

--- a/lib/errors/InvalidConsumerOffsetError.js
+++ b/lib/errors/InvalidConsumerOffsetError.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const util = require('util');
-const NestedError = require('nested-error-stacks');
+var util = require('util');
+var NestedError = require('nested-error-stacks');
 
 /**
  * The offset for the comsumer is invalid
@@ -10,7 +10,7 @@ const NestedError = require('nested-error-stacks');
  *
  * @constructor
  */
-const InvalidConsumerOffsetError = function (message, nested) {
+var InvalidConsumerOffsetError = function (message, nested) {
   NestedError.apply(this, arguments);
 };
 

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -511,7 +511,7 @@ HighLevelConsumer.prototype.init = function () {
  * @param {Boolean} Don't commit when initing consumer
  */
 HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
-  this.topicPayloads.forEach(p => {
+  this.topicPayloads.forEach(function (p) {
     if (!_.isEmpty(topics[p.topic]) && topics[p.topic][p.partition] !== undefined) {
       var offset = topics[p.topic][p.partition];
       if (offset === -1) offset = 0;

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const debug = require('debug');
+var debug = require('debug');
 
-let loggerProvider = debugLoggerProvider;
+var loggerProvider = debugLoggerProvider;
 
 module.exports = exports = function getLogger (name) {
   return loggerProvider(name);
@@ -13,7 +13,7 @@ exports.setLoggerProvider = function setLoggerProvider (provider) {
 };
 
 function debugLoggerProvider (name) {
-  let logger = debug(name);
+  var logger = debug(name);
   logger = logger.bind(logger);
 
   return {

--- a/lib/offset.js
+++ b/lib/offset.js
@@ -23,7 +23,7 @@ util.inherits(Offset, events.EventEmitter);
 
 Offset.prototype.fetch = function (payloads, cb) {
   if (!this.ready) {
-    this.once('ready', () => this.fetch(payloads, cb));
+    this.once('ready', function () { this.fetch(payloads, cb) });
     return;
   }
   this.client.sendOffsetRequest(this.buildPayloads(payloads), cb);
@@ -41,7 +41,7 @@ Offset.prototype.buildPayloads = function (payloads) {
 
 Offset.prototype.commit = function (groupId, payloads, cb) {
   if (!this.ready) {
-    this.once('ready', () => this.commit(groupId, payloads, cb));
+    this.once('ready', function () { this.commit(groupId, payloads, cb) } );
     return;
   }
   this.client.sendOffsetCommitRequest(groupId, this.buildPayloads(payloads), cb);
@@ -49,7 +49,7 @@ Offset.prototype.commit = function (groupId, payloads, cb) {
 
 Offset.prototype.fetchCommits = function (groupId, payloads, cb) {
   if (!this.ready) {
-    this.once('ready', () => this.fetchCommits(groupId, payloads, cb));
+    this.once('ready', function () { this.fetchCommits(groupId, payloads, cb) } );
     return;
   }
   this.client.sendOffsetFetchRequest(groupId, this.buildPayloads(payloads), cb);
@@ -67,17 +67,17 @@ Offset.prototype.fetchEarliestOffsets = function (topics, cb) {
 function fetchOffsets (offset, topics, cb, when) {
   if (!offset.ready) {
     if (when === -1) {
-      offset.once('ready', () => offset.fetchLatestOffsets(topics, cb));
+      offset.once('ready', function () { offset.fetchLatestOffsets(topics, cb) } );
     } else if (when === -2) {
-      offset.once('ready', () => offset.fetchEarliestOffsets(topics, cb));
+      offset.once('ready', function () { offset.fetchEarliestOffsets(topics, cb) } );
     }
     return;
   }
   async.waterfall([
-    callback => {
+    function (callback) {
       offset.client.loadMetadataForTopics(topics, callback);
     },
-    (topicsMetaData, callback) => {
+    function (topicsMetaData, callback) {
       var payloads = [];
       var metaDatas = topicsMetaData[1].metadata;
       Object.keys(metaDatas).forEach(function (topicName) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var InvalidConfigError = require('./errors/InvalidConfigError');
 var legalChars = new RegExp('^[a-zA-Z0-9._-]*$');
-const allowedTopicLength = 249;
+var allowedTopicLength = 249;
 
 function validateConfig (property, value) {
   if (!legalChars.test(value)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,10 +20,10 @@ function validateTopicNames (topics) {
       throw new InvalidConfigError('topic name cannot be . or ..');
     }
     if (topic.length > allowedTopicLength) {
-      throw new InvalidConfigError(`topic name is illegal, cannot be longer than ${allowedTopicLength} characters`);
+      throw new InvalidConfigError('topic name is illegal, cannot be longer than ' + allowedTopicLength + ' characters');
     }
     if (!legalChars.test(topic)) {
-      throw new InvalidConfigError(`topic name ${topic} is illegal, contains a character other than ASCII alphanumerics .,_ and -`);
+      throw new InvalidConfigError('topic name ' + topic + ' is illegal, contains a character other than ASCII alphanumerics .,_ and -');
     }
   });
   return true;


### PR DESCRIPTION
We're locked into using JavaScript/EcmaScript 5 runtime in our project. Small part of the codebase uses Ecmascript 6 constructs (like let,const,class, new anonymous function style and string interpolation) which prevents interoperability with the stlll mainstream es5 runtime  in older node.js interpreters (bundled in most linux distributions).
The porting effort was very minor and quick to do, hope you have time to review and accept change.
Let me know if you have any questions or if you want me to alter changes to be more compliant kafka-node coding guidelines.
Thanks for the great module !

Olli