### PR TITLE
"this" should be "self"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -279,7 +279,7 @@ Client.prototype.sendOffsetRequest = function (payloads, cb) {
   this.send(payloads, encoder, decoder, cb);
 };
 
-Client.prototype.refreshBrokerMetadata = function () {};
+Client.prototype.refreshBrokerMetadata = function () { };
 
 Client.prototype.sendGroupRequest = function (encode, decode, requestArgs) {
   requestArgs = _.values(requestArgs);
@@ -538,7 +538,7 @@ Client.prototype.send = function (payloads, encoder, decoder, cb) {
       // check payloads again
       payloads = self.checkMetadatas(_payloads);
       if (payloads[1].length) {
-        this.refreshBrokerMetadata();
+        self.refreshBrokerMetadata();
         return cb(new errors.BrokerNotAvailableError('Could not find the leader'));
       }
 


### PR DESCRIPTION
Publishing (KafkaClient) / Consuming (KafkaClient and ConsumerGroup) to a "fresh" broker (no topics), there are two issues:
- I receive "LeaderNotAvailable"
- A null reference exception happens at client.js#541

This fixes the null reference exception.

I still receive "LeaderNotAvailable", followed by "BrokerNotAvailableError: Could not find the leader" and then eventually publishing starting working so there's some timing issue, but I'll look into that separately.

Signed-off-by: Michael Haan <haanmd@gmail.com>

