### PR TITLE
Flush queued commits of ConsumerGroupStream on tail end of auto-commit time-out

### DIFF
--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -81,16 +81,22 @@ class ConsumerGroupStream extends Readable {
       return;
     }
 
+    const commits = convertToCommitPayload(this.commitQueue);
+    this.commitQueued(commits, force, callback);
+  }
+
+  commitQueued (commits, force, callback) {
     this.committing = true;
 
     if (!force) {
       this.autoCommitTimer = setTimeout(() => {
         logger.debug('setting committing to false');
         this.committing = false;
+
+        const queuedCommits = convertToCommitPayload(this.commitQueue);
+        if (!_.isEmpty(queuedCommits)) this.commitQueued(queuedCommits);
       }, this.consumerGroup.options.autoCommitIntervalMs);
     }
-
-    const commits = convertToCommitPayload(this.commitQueue);
 
     if (_.isEmpty(commits)) {
       logger.debug('commit ignored. no commits to make.');


### PR DESCRIPTION
I ran into a situation where I pulled multiple messages of a `ConsumerGroupStream` in short succession, after which I reached the high water mark. The offset commit was triggered by the first read of the stream, with subsequent commits "throttled" and pushed to a queue. However, because no additional messages were read from the stream, another call to `stream.commit` never happens, with the commit stuck in the queue. This, in turn, lead to messages being consumed more than once.

To solve the issue I added a check to flush anything in the queue at the tail end of the throttling time-out.

I looked for a place to add tests, but couldn't find any for `ConsumerGroupStream` at all. Before I put a lot more effort in I thought I'd check whether this has any chance of getting merged at all! Also happy to take another approach; I'm new to the codebase so not quite sure how this is handled in other areas of it (if at all).