### PR TITLE
Upgrade snappy

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">4.4.7"
   },
   "optionalDependencies": {
-    "snappy": "^5.0.5"
+    "snappy": "^6.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.12",


### PR DESCRIPTION
Breaking is dropped support for older nodes (and new snappy version).

I haven't tested this, though

https://github.com/kesla/node-snappy/blob/master/CHANGELOG.md