### PR TITLE
Added missing callbacks in the commit()

### DIFF
--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -78,7 +78,7 @@ class ConsumerGroupStream extends Readable {
 
     if (this.committing && !force) {
       logger.debug('skipping committing');
-      return callback && callback();
+      return callback && callback(null);
     }
 
     this.committing = true;
@@ -94,7 +94,7 @@ class ConsumerGroupStream extends Readable {
 
     if (_.isEmpty(commits)) {
       logger.debug('commit ignored. no commits to make.');
-      return callback && callback();
+      return callback && callback(null);
     }
 
     logger.debug('committing', commits);

--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -78,7 +78,7 @@ class ConsumerGroupStream extends Readable {
 
     if (this.committing && !force) {
       logger.debug('skipping committing');
-      return;
+      return callback && callback();
     }
 
     this.committing = true;
@@ -94,7 +94,7 @@ class ConsumerGroupStream extends Readable {
 
     if (_.isEmpty(commits)) {
       logger.debug('commit ignored. no commits to make.');
-      return;
+      return callback && callback();
     }
 
     logger.debug('committing', commits);


### PR DESCRIPTION
Added missing callback function in the code. 

This is needed when stream.close() function is called and subsequent clean up happens.