### PR TITLE
Fix fromOffset option for ConsumerStream

### DIFF
--- a/lib/consumerStream.js
+++ b/lib/consumerStream.js
@@ -223,7 +223,7 @@ ConsumerStream.prototype.init = function () {
       return self.emit('error', err);
     }
 
-    var start = function() {
+    var start = function () {
       self.emit('readable');
       self.ready = true;
 

--- a/lib/consumerStream.js
+++ b/lib/consumerStream.js
@@ -223,13 +223,7 @@ ConsumerStream.prototype.init = function () {
       return self.emit('error', err);
     }
 
-    self.client.sendOffsetFetchRequest(self.options.groupId, self.payloads, function (err, topics) {
-      if (err) {
-        return self.emit('error', err);
-      }
-
-      self.updateOffsets(topics, true);
-
+    var start = function() {
       self.emit('readable');
       self.ready = true;
 
@@ -240,6 +234,19 @@ ConsumerStream.prototype.init = function () {
           self.fetch();
         });
       }
+    };
+
+    if (self.options.fromOffset) {
+      return start();
+    }
+
+    self.client.sendOffsetFetchRequest(self.options.groupId, self.payloads, function (err, topics) {
+      if (err) {
+        return self.emit('error', err);
+      }
+
+      self.updateOffsets(topics, true);
+      start();
     });
   });
 };


### PR DESCRIPTION
I ran into an issue where I needed `ConsumerStream` to start consuming from a certain offset. I passed it as a payload during construction, and `fromOffset: true`. However, there wasn't any code handling this.

For the implementation I looked at how it's handled in `Consumer`, to stay consistent.