### PR TITLE
Don't hang process on shutdown

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -553,7 +553,7 @@ function autoCommit (force, cb) {
   this.committing = true;
   setTimeout(function () {
     this.committing = false;
-  }.bind(this), this.options.autoCommitIntervalMs);
+  }.bind(this), this.options.autoCommitIntervalMs).unref();
 
   var commits = this.topicPayloads.filter(function (p) { return p.offset !== -1; });
 


### PR DESCRIPTION
The setTimeout will hold a process open during process shutdown, even after the consumer has been closed.

By simply adding unref, node will no longer hold the process open for this task and allow it to shutdown correctly.