### PR TITLE
Support for IPv6

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -92,10 +92,13 @@ util.inherits(KafkaClient, Client);
      */
 
 function parseHost (hostString) {
-  const piece = hostString.split(':');
+  const ip = hostString.substring(0, hostString.lastIndexOf(':'));
+  const port = hostString.substring(hostString.lastIndexOf(':') + 1);
+  const isIpv6 = ip.match(/\[(.*)\]/);
+  const host = isIpv6 ? isIpv6[1] : ip;
   return {
-    host: piece[0],
-    port: piece[1]
+    host,
+    port
   };
 }
 


### PR DESCRIPTION
We should support kafka-node for IPv6 as well. I've updated the parseHost function to parse both IPv4 and IPv6 addresses. According to RFC 3986 (https://tools.ietf.org/html/rfc3986), an IPv6 address is supposed to be wrapped by brackets and separated with port number by a colon. 

eg. [2001:bd4:32:4d21:225d:1f22:113:2535]:9092

This an example of presented IPv6 address a client is supposed to receive as the kafkaHost option.