### PR TITLE
Clear socket.waiting before invoking callbacks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -753,6 +753,10 @@ Client.prototype.handleReceivedData = function (socket) {
   var size = buffer.readUInt32BE(0) + 4;
 
   if (buffer.length >= size) {
+    if (socket.longpolling) {
+      socket.waiting = false;
+    }
+
     var resp = buffer.shallowSlice(0, size);
     var correlationId = resp.readUInt32BE(4);
     var handlers = this.unqueueCallback(socket, correlationId);
@@ -766,9 +770,6 @@ Client.prototype.handleReceivedData = function (socket) {
       logger.error(`missing handlers for Correlation ID: ${correlationId}`);
     }
     buffer.consume(size);
-    if (socket.longpolling) {
-      socket.waiting = false;
-    }
   } else {
     return;
   }


### PR DESCRIPTION
If we `pause()` and then later `resume()` a consumer within a 'done' callback, we can get into a situation where the consumer doesn't actually resume because `sendToBroker` bails out early (because `broker.socket.waiting` is still `true` while the 'done' callback is being invoked, so the fetch request gets thrown away).

To work around this I've had to use `setImmediate(() => consumer.resume())` to schedule the resume() to occur after the `socket.waiting` flag has been reset. It works well enough, but it's not very intuitive.

This change simply moves the `socket.waiting` reset to occur before we fire off the decoder & associated callbacks. I _think_ this is pretty low risk, but perhaps you can think of a reason why we wouldn't want to do this.

Something else to consider: it can be somewhat surprising that requests to brokers are simply "thrown away" if the waiting flag is set: at a minimum, a log message before the `continue` in `Client.sendToBroker` would be great (I can add this if you like, it's easy enough).I fFeel like a more "correct" approach would be to fire the callback before that same `continue` so callers can at least notice that something went screwy, but that seems like a larger change.