### PR TITLE
Always clear KafkaClient cb queue with err (#824)

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -578,15 +578,10 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   });
   socket.on('close', function (hadError) {
     self.emit('close', this);
-    if (hadError) {
-      self.clearCallbackQueue(
-        this,
-        this.error != null ? this.error : new errors.BrokerNotAvailableError('Broker not available')
-      );
-    } else {
-      logger.debug(`clearing ${this.addr} callback queue without error`);
-      self.clearCallbackQueue(this);
-    }
+    self.clearCallbackQueue(
+      this,
+      this.error != null ? this.error : new errors.BrokerNotAvailableError('Broker not available')
+    );
     retry(this);
   });
   socket.on('end', function () {


### PR DESCRIPTION
Failure to do this can cause confusion in user code because callbacks
passed to Producer.send(...) never get invoked.

---

Possible fix for #824, can't reproduce with this change in play. May need some guidance RE: testing.