### PR TITLE
Partition not selected correctly with KeyedPartitioner because 'undefined' always passed to it.

### DIFF
--- a/lib/baseProducer.js
+++ b/lib/baseProducer.js
@@ -124,7 +124,7 @@ BaseProducer.prototype.buildPayloads = function (payloads, topicMetadata) {
   payloads.forEach(p => {
     p.partition = p.hasOwnProperty('partition')
       ? p.partition
-      : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.key);
+      : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.messages && p.messages[0].key);
     p.attributes = p.hasOwnProperty('attributes') ? p.attributes : 0;
     let messages = _.isArray(p.messages) ? p.messages : [p.messages];
 


### PR DESCRIPTION
Using a slightly modified version of one of the examples to include a KeyedPartitioner:

```
var kafka = require('kafka-node');
var Producer = kafka.Producer;
var KeyedMessage = kafka.KeyedMessage;
var Client = kafka.KafkaClient;
var client = new Client('localhost:9093');
var topic = 'test2';
var producer = new Producer(client, { requireAcks: 1, partitionerType: 3 });

producer.on('ready', function () {
  var keyedMessage = new KeyedMessage('user56', 'a keyed message');

  client.refreshMetadata([topic], err => {
      console.log(err);
    producer.send([
        { topic: topic, messages: [keyedMessage] }
    ], function (err, result) {
        console.log(err || result);
        process.exit();
   });
  });

});

producer.on('error', function (err) {
  console.log('error', err);
});

```

I noticed that it is always being sent to the same partition 1 regardless of key:

```
worker1 read msg Topic="test2" Partition=1 Offset=5 message={"topic":"test2","value":"a keyed message","offset":5,"partition":1,"highWaterOffset":6,"key":"0.33877171392795935"}
worker1 read msg Topic="test2" Partition=1 Offset=6 message={"topic":"test2","value":"a keyed message","offset":6,"partition":1,"highWaterOffset":7,"key":"user2"}
worker1 read msg Topic="test2" Partition=1 Offset=7 message={"topic":"test2","value":"a keyed message","offset":7,"partition":1,"highWaterOffset":8,"key":"alert57"}
worker1 read msg Topic="test2" Partition=1 Offset=8 message={"topic":"test2","value":"a keyed message","offset":8,"partition":1,"highWaterOffset":9,"key":"alert58"}
```

This seems to be because buildPayloads in BaseProducer assumes there is a key property on the message when in fact they look like this:

```
{ topic: 'test2',
  messages: 
   [ KeyedMessage {
       magic: 0,
       attributes: 0,
       key: 'user56',
       value: 'a keyed message',
       timestamp: 1513653203458 } ] }
```

This PR fixes that by using the first message to determine the partition to send to.