### PR TITLE
Fix leader not available issue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -513,7 +513,7 @@ Client.prototype.refreshMetadata = function (topicNames, cb) {
 
 Client.prototype.send = function (payloads, encoder, decoder, cb) {
   var self = this;
-  var _payloads = payloads;
+  var _payloads = JSON.parse(JSON.stringify(payloads));
   // payloads: [ [metadata exists], [metadata not exists] ]
   payloads = this.checkMetadatas(payloads);
   if (payloads[0].length && !payloads[1].length) {


### PR DESCRIPTION
Make sure that the second check of the payloads is performed on the initial payloads array. In very specific cases the payloads array might change, causing the second check of the payloads (line 539) to fail (as _payload references the original payload).