### PR TITLE
Add support for brokers separating external and internal traffic (introduced in KIP-103)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -126,7 +126,7 @@ Client.prototype.connect = function () {
 Client.prototype.setupBrokerProfiles = function (brokers) {
   this.brokerProfiles = Object.create(null);
   var self = this;
-  var protocol = self.ssl ? 'ssl:' : 'plaintext:';
+  var protocol = self.ssl ? 'SSL' : 'PLAINTEXT';
 
   Object.keys(brokers).forEach(function (key) {
     var brokerProfile = brokers[key];
@@ -134,7 +134,13 @@ Client.prototype.setupBrokerProfiles = function (brokers) {
 
     if (brokerProfile.endpoints && brokerProfile.endpoints.length) {
       var endpoint = _.find(brokerProfile.endpoints, function (endpoint) {
-        return url.parse(endpoint).protocol === protocol;
+        var securityProtocolMap = brokerProfile.listener_security_protocol_map;
+        var listenerName = url.parse(endpoint).protocol.replace(':', '').toUpperCase();
+        if (securityProtocolMap !== undefined) {
+          return securityProtocolMap[listenerName] === protocol;
+        } else {
+          return listenerName === protocol;
+        }
       });
 
       if (endpoint == null) {

--- a/test/test.client.js
+++ b/test/test.client.js
@@ -198,7 +198,7 @@ describe('Client', function () {
       var clientId = 'kafka-node-client-' + uuid.v4();
       client = new Client(host, clientId);
       client.on('error', function (error) {
-        error.message.should.be.eql('No kafka endpoint found for broker: 1001 with protocol plaintext:');
+        error.message.should.be.eql('No kafka endpoint found for broker: 1001 with protocol PLAINTEXT');
         done();
       });
 
@@ -224,7 +224,7 @@ describe('Client', function () {
       var clientId = 'kafka-node-client-' + uuid.v4();
       client = new Client(host, clientId, undefined, undefined, { rejectUnauthorized: false });
       client.on('error', function (error) {
-        error.message.should.be.eql('No kafka endpoint found for broker: 1001 with protocol ssl:');
+        error.message.should.be.eql('No kafka endpoint found for broker: 1001 with protocol SSL');
         done();
       });
 


### PR DESCRIPTION
Fixes point 1 of Issue #859 

Checks if the `listener.security.protocol.map` property is present in the broker metadata. If it is: it will apply the mapping from listener name to security protocol used before checking whether a listener uses the protocol desired by the kafka-node client.

For point 2 it currently still requires the endpoint to be used by kafka-node to be listed first.