### PR TITLE
Clear topic payload if no partitions are assigned

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -396,6 +396,7 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
       callback
     );
   } else {
+    self.topicPayloads = [];
     // no partitions assigned
     callback(null, false);
   }


### PR DESCRIPTION
This handles case where more consumers join than their are partitions.

when this occurs, one of the consumers may receive no partitions, and
this topicPayloads variable still contained reference to their previous
partition assignment.