### PR TITLE
auto commit and add event for rebalance

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,10 @@ var options = {
   // how to recover from OutOfRangeOffset error (where save offset is past server retention) accepts same value as fromOffset
   outOfRangeOffset: 'earliest', // default
   migrateHLC: false,    // for details please see Migration section below
-  migrateRolling: true
+  migrateRolling: true,
+  // Callback to allow consumers with autoCommit false a chance to commit before a rebalance finishes
+  // isAlreadyMember will be false on the first connection, and true on rebalances triggered after that
+  onRebalance: (isAlreadyMember, callback) => { callback(); } // or null
 };
 
 var consumerGroup = new ConsumerGroup(options, ['RebalanceTopic', 'RebalanceTest']);

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -47,6 +47,7 @@ const DEFAULTS = {
   connectOnReady: true,
   migrateHLC: false,
   migrateRolling: true,
+  onRebalance: null,
   protocol: ['roundrobin']
 };
 
@@ -438,6 +439,20 @@ ConsumerGroup.prototype.connect = function () {
 
   async.waterfall(
     [
+      function (callback) {
+        if (typeof self.options.onRebalance === 'function') {
+          self.options.onRebalance(self.generationId != null && self.memberId != null, callback);
+          return;
+        }
+        callback();
+      },
+      function (callback) {
+        if (self.options.autoCommit && self.generationId != null && self.memberId) {
+          self.commit(true, callback);
+          return;
+        }
+        callback();
+      },
       function (callback) {
         if (self.client.coordinatorId) {
           return callback(null, null);

--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -50,11 +50,7 @@ class ConsumerGroupStream extends Readable {
           return;
         }
         autoCommitCalled = true;
-        if (self.autoCommit) {
-          self.commit(null, true, callback);
-        } else {
-          callback();
-        }
+        self.commit(null, true, callback);
       };
       if (typeof originalOnRebalance === 'function') {
         try {

--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -33,11 +33,40 @@ class ConsumerGroupStream extends Readable {
     super({ objectMode: true, highWaterMark: options.highWaterMark || DEFAULT_HIGH_WATER_MARK });
 
     _.defaultsDeep(options || {}, DEFAULTS);
+    const self = this;
 
     this.autoCommit = options.autoCommit;
 
     options.connectOnReady = false;
     options.autoCommit = false;
+    const originalOnRebalance = options.onRebalance;
+    options.onRebalance = function (isAlreadyMember, callback) {
+      let autoCommitCalled = false;
+      const autoCommit = function () {
+        // We might end up calling this twice due to the try/catch below.
+        // We auto call this on error expecting that autoCommit hasn't been called
+        // yet, but it is possible that it was called, and then an error got thrown
+        if (autoCommitCalled) {
+          return;
+        }
+        autoCommitCalled = true;
+        if (self.autoCommit) {
+          self.commit(null, true, callback);
+        } else {
+          callback();
+        }
+      };
+      if (typeof originalOnRebalance === 'function') {
+        try {
+          originalOnRebalance(isAlreadyMember, autoCommit);
+        } catch (e) {
+          autoCommit();
+          throw e;
+        }
+      } else {
+        autoCommit();
+      }
+    };
 
     this.consumerGroup = new ConsumerGroup(options, topics);
 

--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -41,21 +41,13 @@ class ConsumerGroupStream extends Readable {
     options.autoCommit = false;
     const originalOnRebalance = options.onRebalance;
     options.onRebalance = function (isAlreadyMember, callback) {
-      let autoCommitCalled = false;
-      const autoCommit = function (err) {
-        // We might end up calling this twice due to the try/catch below.
-        // We auto call this on error expecting that autoCommit hasn't been called
-        // yet, but it is possible that it was called, and then an error got thrown
-        if (autoCommitCalled) {
-          return;
-        }
-        autoCommitCalled = true;
+      const autoCommit = _.once(function (err) {
         if (err) {
           callback(err);
         } else {
           self.commit(null, true, callback);
         }
-      };
+      });
       if (typeof originalOnRebalance === 'function') {
         try {
           originalOnRebalance(isAlreadyMember, autoCommit);

--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -42,7 +42,7 @@ class ConsumerGroupStream extends Readable {
     const originalOnRebalance = options.onRebalance;
     options.onRebalance = function (isAlreadyMember, callback) {
       let autoCommitCalled = false;
-      const autoCommit = function () {
+      const autoCommit = function (err) {
         // We might end up calling this twice due to the try/catch below.
         // We auto call this on error expecting that autoCommit hasn't been called
         // yet, but it is possible that it was called, and then an error got thrown
@@ -50,14 +50,17 @@ class ConsumerGroupStream extends Readable {
           return;
         }
         autoCommitCalled = true;
-        self.commit(null, true, callback);
+        if (err) {
+          callback(err);
+        } else {
+          self.commit(null, true, callback);
+        }
       };
       if (typeof originalOnRebalance === 'function') {
         try {
           originalOnRebalance(isAlreadyMember, autoCommit);
         } catch (e) {
-          autoCommit();
-          throw e;
+          autoCommit(e);
         }
       } else {
         autoCommit();


### PR DESCRIPTION
Should resolve #787

If auto commit is true, commit before we rejoin the group on a rebalance
According to the kafka protcol, commits are allowed during this stage, as the generation ID has not been bumped yet.

If auto commit is disabled, implementors need a way to decide what to commit, so an onRebalance option was added.

Implementors can perform commits during this method and call back when done to finish the rebalance.