### PR TITLE
Fix Stale Commit Queue for ConsumerGroupStream

### DIFF
--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -19,7 +19,7 @@ function convertToCommitPayload (messages) {
         ret.push({
           topic: topic,
           partition: partition,
-          offset: offset + 1,
+          offset: offset,
           metadata: 'm'
         });
       }
@@ -73,7 +73,7 @@ class ConsumerGroupStream extends Readable {
 
   commit (message, force, callback) {
     if (message != null && message.offset !== -1) {
-      _.set(this.commitQueue, [message.topic, message.partition], message.offset);
+      _.set(this.commitQueue, [message.topic, message.partition], message.offset + 1);
     }
 
     if (this.committing && !force) {


### PR DESCRIPTION
The commit at https://github.com/SOHU-Co/kafka-node/commit/abc160986765ebf94b121d56cadaa4a3d426559a introduced a bug
where the offset was incremented at the wrong location.

commitQueued then expected the offset committed to match what is currently in the queue, and that commit broke this.

This results in commit records never being correctly removed from the commitQueue, leading to
weird behavior when committing and messages being consumed twice when rebalances occur relating
to committing stale offsets.

