### PR TITLE
Add missing super ctor calls across code base, fix small quirks

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -2,9 +2,10 @@
 
 var KafkaClient = require('./kafkaClient');
 var util = require('util');
-var events = require('events');
+var EventEmitter = require('events');
 
-var Admin = function (kafkaClient) {
+function Admin (kafkaClient) {
+  EventEmitter.call(this);
   if (!(kafkaClient instanceof KafkaClient)) {
     throw new Error("'Admin' only accepts 'KafkaClient' for its kafka client.");
   }
@@ -22,8 +23,8 @@ var Admin = function (kafkaClient) {
   this.client.on('error', function (err) {
     self.emit('error', err);
   });
-};
-util.inherits(Admin, events.EventEmitter);
+}
+util.inherits(Admin, EventEmitter);
 
 Admin.prototype.listGroups = function (cb) {
   if (!this.ready) {

--- a/lib/baseProducer.js
+++ b/lib/baseProducer.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 var util = require('util');
-var events = require('events');
+var EventEmitter = require('events');
 var _ = require('lodash');
 var protocol = require('./protocol');
 var Message = protocol.Message;
@@ -53,6 +53,7 @@ var DEFAULTS = {
  * @constructor
  */
 function BaseProducer (client, options, defaultPartitionerType, customPartitioner) {
+  EventEmitter.call(this);
   options = options || {};
 
   this.ready = false;
@@ -75,7 +76,7 @@ function BaseProducer (client, options, defaultPartitionerType, customPartitione
   this.connect();
 }
 
-util.inherits(BaseProducer, events.EventEmitter);
+util.inherits(BaseProducer, EventEmitter);
 
 BaseProducer.prototype.connect = function () {
   // emiter...

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,10 +48,10 @@ const MAX_INT32 = 2147483647;
  * @constructor
  */
 function Client (connectionString, clientId, zkOptions, noAckBatchOptions, sslOptions) {
-  EventEmitter.call(this);
   if (this instanceof Client === false) {
     return new Client(connectionString, clientId, zkOptions, noAckBatchOptions, sslOptions);
   }
+  EventEmitter.call(this);
   this.setMaxListeners(20); // waitUntilReady can trigger lots of listeners under high activity, so increase threshold
 
   this.sslOptions = sslOptions;

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,7 @@ var util = require('util');
 var _ = require('lodash');
 var async = require('async');
 var retry = require('retry');
-var events = require('events');
+var EventEmitter = require('events');
 var errors = require('./errors');
 var getCodec = require('./codec');
 var protocol = require('./protocol');
@@ -47,10 +47,12 @@ const MAX_INT32 = 2147483647;
  *
  * @constructor
  */
-var Client = function (connectionString, clientId, zkOptions, noAckBatchOptions, sslOptions) {
+function Client (connectionString, clientId, zkOptions, noAckBatchOptions, sslOptions) {
+  EventEmitter.call(this);
   if (this instanceof Client === false) {
     return new Client(connectionString, clientId, zkOptions, noAckBatchOptions, sslOptions);
   }
+  this.setMaxListeners(20); // waitUntilReady can trigger lots of listeners under high activity, so increase threshold
 
   this.sslOptions = sslOptions;
   this.ssl = !!sslOptions;
@@ -73,9 +75,9 @@ var Client = function (connectionString, clientId, zkOptions, noAckBatchOptions,
   this.brokerMetadata = {};
   this.ready = false;
   this.connect();
-};
+}
 
-util.inherits(Client, events.EventEmitter);
+util.inherits(Client, EventEmitter);
 
 Client.prototype.connect = function () {
   var zk = (this.zk = new Zookeeper(this.connectionString, this.zkOptions));

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var _ = require('lodash');
-var events = require('events');
+var EventEmitter = require('events');
 var logger = require('./logging')('kafka-node:Consumer');
 var utils = require('./utils');
 
@@ -26,7 +26,8 @@ var nextId = (function () {
   };
 })();
 
-var Consumer = function (client, topics, options) {
+function Consumer (client, topics, options) {
+  EventEmitter.call(this);
   if (!topics) {
     throw new Error('Must have payloads');
   }
@@ -46,8 +47,8 @@ var Consumer = function (client, topics, options) {
   if (this.options.groupId) {
     utils.validateConfig('options.groupId', this.options.groupId);
   }
-};
-util.inherits(Consumer, events.EventEmitter);
+}
+util.inherits(Consumer, EventEmitter);
 
 Consumer.prototype.buildPayloads = function (payloads) {
   var self = this;

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -3,7 +3,7 @@
 const logger = require('./logging')('kafka-node:ConsumerGroup');
 const util = require('util');
 const EventEmitter = require('events');
-const highLevelConsumer = require('./highLevelConsumer');
+const HighLevelConsumer = require('./highLevelConsumer');
 const Client = require('./client');
 const KafkaClient = require('./kafkaClient');
 const Offset = require('./offset');
@@ -51,7 +51,7 @@ const DEFAULTS = {
 };
 
 function ConsumerGroup (memberOptions, topics) {
-  EventEmitter.call(this);
+  EventEmitter.call(this); // Intentionally not calling HighLevelConsumer to avoid constructor logic
   const self = this;
   this.options = _.defaults(memberOptions || {}, DEFAULTS);
 
@@ -199,7 +199,7 @@ function ConsumerGroup (memberOptions, topics) {
   this.topicPayloads = [];
 }
 
-util.inherits(ConsumerGroup, highLevelConsumer);
+util.inherits(ConsumerGroup, HighLevelConsumer);
 
 ConsumerGroup.prototype.reconnectIfNeeded = function () {
   logger.debug('trying to reconnect if needed');

--- a/lib/consumerGroupMigrator.js
+++ b/lib/consumerGroupMigrator.js
@@ -6,7 +6,7 @@ const async = require('async');
 const logger = require('./logging')('kafka-node:ConsumerGroupMigrator');
 const zookeeper = require('node-zookeeper-client');
 const _ = require('lodash');
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events');
 const NUMER_OF_TIMES_TO_VERIFY = 4;
 const VERIFY_WAIT_TIME_MS = 1500;
 

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var _ = require('lodash');
-var events = require('events');
+var EventEmitter = require('events');
 var uuid = require('uuid');
 var async = require('async');
 var errors = require('./errors');
@@ -34,6 +34,7 @@ var DEFAULTS = {
 };
 
 var HighLevelConsumer = function (client, topics, options) {
+  EventEmitter.call(this);
   if (!topics) {
     throw new Error('Must have payloads');
   }
@@ -62,7 +63,7 @@ var HighLevelConsumer = function (client, topics, options) {
     validateConfig('options.groupId', this.options.groupId);
   }
 };
-util.inherits(HighLevelConsumer, events.EventEmitter);
+util.inherits(HighLevelConsumer, EventEmitter);
 
 HighLevelConsumer.prototype.buildPayloads = function (payloads) {
   var self = this;

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -2,6 +2,7 @@
 
 const Client = require('./client');
 const logger = require('./logging')('kafka-node:KafkaClient');
+const EventEmitter = require('events');
 const async = require('async');
 const retry = require('retry');
 const assert = require('assert');
@@ -38,10 +39,12 @@ const DEFAULTS = {
     maxTimeout: 60 * 1000,
     randomize: true
   },
-  maxAsyncRequests: 10
+  maxAsyncRequests: 10,
+  noAckBatchOptions: null
 };
 
 const KafkaClient = function (options) {
+  EventEmitter.call(this); // Intentionally not calling Client to avoid constructor logic
   this.options = _.defaultsDeep(options || {}, DEFAULTS);
 
   this.sslOptions = this.options.sslOptions;
@@ -56,7 +59,7 @@ const KafkaClient = function (options) {
   }
 
   this.clientId = this.options.clientId || 'kafka-node-client';
-  this.noAckBatchOptions = this.noAckBatchOptions;
+  this.noAckBatchOptions = this.options.noAckBatchOptions;
   this.brokers = {};
   this.longpollingBrokers = {};
   this.topicMetadata = {};

--- a/lib/offset.js
+++ b/lib/offset.js
@@ -2,9 +2,10 @@
 
 var util = require('util');
 var async = require('async');
-var events = require('events');
+var EventEmitter = require('events');
 
-var Offset = function (client) {
+function Offset (client) {
+  EventEmitter.call(this);
   var self = this;
   this.client = client;
   this.ready = this.client.ready;
@@ -18,8 +19,8 @@ var Offset = function (client) {
   this.client.on('error', function (err) {
     self.emit('error', err);
   });
-};
-util.inherits(Offset, events.EventEmitter);
+}
+util.inherits(Offset, EventEmitter);
 
 Offset.prototype.fetch = function (payloads, cb) {
   if (!this.ready) {

--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var util = require('util');
-var _ = require('lodash');
+const util = require('util');
+const _ = require('lodash');
 
-var Partitioner = function () { };
+function Partitioner () { }
 
-var DefaultPartitioner = function () { };
+function DefaultPartitioner () {
+  Partitioner.call(this);
+}
 util.inherits(DefaultPartitioner, Partitioner);
 
 DefaultPartitioner.prototype.getPartition = function (partitions) {
@@ -16,9 +18,10 @@ DefaultPartitioner.prototype.getPartition = function (partitions) {
   }
 };
 
-var CyclicPartitioner = function () {
+function CyclicPartitioner () {
+  Partitioner.call(this);
   this.c = 0;
-};
+}
 util.inherits(CyclicPartitioner, Partitioner);
 
 CyclicPartitioner.prototype.getPartition = function (partitions) {
@@ -26,24 +29,28 @@ CyclicPartitioner.prototype.getPartition = function (partitions) {
   return partitions[this.c++ % partitions.length];
 };
 
-var RandomPartitioner = function () { };
+function RandomPartitioner () {
+  Partitioner.call(this);
+}
 util.inherits(RandomPartitioner, Partitioner);
 
 RandomPartitioner.prototype.getPartition = function (partitions) {
   return partitions[Math.floor(Math.random() * partitions.length)];
 };
 
-var KeyedPartitioner = function () { };
+function KeyedPartitioner () {
+  Partitioner.call(this);
+}
 util.inherits(KeyedPartitioner, Partitioner);
 
 // Taken from oid package (Dan Bornstein)
 // Copyright The Obvious Corporation.
 KeyedPartitioner.prototype.hashCode = function (string) {
-  var hash = 0;
+  let hash = 0;
   if (string) {
-    var length = string.toString().length;
+    const length = string.toString().length;
 
-    for (var i = 0; i < length; i++) {
+    for (let i = 0; i < length; i++) {
       hash = ((hash * 31) + string.charCodeAt(i)) & 0x7fffffff;
     }
   }
@@ -54,13 +61,14 @@ KeyedPartitioner.prototype.hashCode = function (string) {
 KeyedPartitioner.prototype.getPartition = function (partitions, key) {
   key = key || '';
 
-  var index = this.hashCode(key) % partitions.length;
+  const index = this.hashCode(key) % partitions.length;
   return partitions[index];
 };
 
-var CustomPartitioner = function (partitioner) {
+function CustomPartitioner (partitioner) {
+  Partitioner.call(this);
   this.getPartition = partitioner;
-};
+}
 util.inherits(CustomPartitioner, Partitioner);
 
 module.exports.DefaultPartitioner = DefaultPartitioner;

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -3,7 +3,7 @@
 var zookeeper = require('node-zookeeper-client');
 var util = require('util');
 var async = require('async');
-var EventEmiter = require('events').EventEmitter;
+var EventEmitter = require('events');
 var logger = require('./logging')('kafka-node:zookeeper');
 
 /**
@@ -15,6 +15,7 @@ var logger = require('./logging')('kafka-node:zookeeper');
  * @constructor
  */
 var Zookeeper = function (connectionString, options) {
+  EventEmitter.call(this);
   this.client = zookeeper.createClient(connectionString, options);
 
   var that = this;
@@ -27,7 +28,7 @@ var Zookeeper = function (connectionString, options) {
   this.client.connect();
 };
 
-util.inherits(Zookeeper, EventEmiter);
+util.inherits(Zookeeper, EventEmitter);
 
 Zookeeper.prototype.unregisterConsumer = function (groupId, consumerId, cb) {
   var path = '/consumers/' + groupId + '/ids/' + consumerId;


### PR DESCRIPTION
Classes that were missing ctors would be missing initialization code for Domains, which could introduce bad bahavior. It's overall the responsible thing to do to always execute your super ctor.

Other fixes:

1) noAckBatchOptions in KafkaClient was not being read correctly from options
2) Use EventEmitter directly as name instead of events.EventEmitter so that IDE code completion behaves correctly
3) Fix some typos/case incorrectness
4) Raise Client max event listeners, as high volume publishing while a broker is not ready schedules lots of 'onBrokerReady' events which triggers nodes memory leak warning. Give a higher threshold.
5) Even though Partitioner has no body, still added super ctor for correctness, so if a body is added in the future, bugs are prevented.
6) Clean up some code style to use named functions instead of anonymous functions for consistency, and use let/const in some places
7) Made notes about intentionally not calling KafkaClient and ConsumerGroup's ctors, although this is a sign of maintenance concerns as this will make it more difficult to rewrite to classes, and this should be resolved in the future.