### PR TITLE
Wrap ConsumerGroup.onRebalance to avoid waterfall bug

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -442,7 +442,12 @@ ConsumerGroup.prototype.connect = function () {
     [
       function (callback) {
         if (typeof self.options.onRebalance === 'function') {
-          self.options.onRebalance(self.generationId != null && self.memberId != null, callback);
+          self.options.onRebalance(self.generationId != null && self.memberId != null, function (error) {
+            if (error) {
+              return callback(error);
+            }
+            callback(null);
+          });
           return;
         }
         callback(null);


### PR DESCRIPTION
If the onRebalance function yields a value, it would be reflected
into the waterfall and move the callback to the 2nd parameter.

see #918