### PR TITLE
WIP: basic support for SASL/PLAIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     - KAFKA_VERSION=0.9
     - KAFKA_VERSION=0.10
     - KAFKA_VERSION=0.11
+    - KAFKA_VERSION=1.0
+    - KAFKA_VERSION=1.1
   global:
     # - DEBUG=kafka-node:*
     - KAFKA_ADVERTISED_HOST_NAME=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ New KafkaClient connects directly to Kafka brokers instead of connecting to zook
 * `connectRetryOptions` : object hash that applies to the initial connection. see [retry](https://www.npmjs.com/package/retry) module for these options.
 * `idleConnection` : allows the broker to disconnect an idle connection from a client (otherwise the clients continues to reconnect after being disconnected). The value is elapsed time in ms without any data written to the TCP socket. default: 5 minutes
 * `maxAsyncRequests` : maximum async operations at a time toward the kafka cluster. default: 10
-* `sslOptions`: **Object**, options to be passed to the tls broker sockets, ex. { rejectUnauthorized: false } (Kafka +0.9)
+* `sslOptions`: **Object**, options to be passed to the tls broker sockets, ex. `{ rejectUnauthorized: false }` (Kafka 0.9+)
+* `sasl`: **Object**, SASL authentication configuration (only SASL/PLAIN is currently supported), ex. `{ mechanism: 'plain', username: 'foo', password: 'bar' }` (Kafka 0.10+)
 
 ### Example
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,18 +15,13 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
+      KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093"
       KAFKA_SSL_KEYSTORE_LOCATION: "/var/private/ssl/certs/server.keystore.jks"
       KAFKA_SSL_KEYSTORE_PASSWORD: "password"
       KAFKA_SSL_KEY_PASSWORD: "password"
       KAFKA_SSL_TRUSTSTORE_LOCATION: "/var/private/ssl/certs/server.truststore.jks"
       KAFKA_SSL_TRUSTSTORE_PASSWORD: "password"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
-      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
-      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
-      KAFKA_SUPER_USERS: "User:admin,User:broker"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"
       KAFKA_CREATE_TOPICS: "DuplicateMessageTest:1:1,RebalanceTopic:3:1,ExampleTopic:1:1,RebalanceTest:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,19 +9,26 @@ services:
     ports:
       - "9092:9092"
       - "9093:9093"
+      - "9094:9094"
     depends_on:
       - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: ${KAFKA_ADVERTISED_HOST_NAME}
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093"
+      KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
       KAFKA_SSL_KEYSTORE_LOCATION: "/var/private/ssl/certs/server.keystore.jks"
       KAFKA_SSL_KEYSTORE_PASSWORD: "password"
       KAFKA_SSL_KEY_PASSWORD: "password"
       KAFKA_SSL_TRUSTSTORE_LOCATION: "/var/private/ssl/certs/server.truststore.jks"
       KAFKA_SSL_TRUSTSTORE_PASSWORD: "password"
+      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+      KAFKA_SUPER_USERS: "User:admin,User:broker"
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"
       KAFKA_CREATE_TOPICS: "DuplicateMessageTest:1:1,RebalanceTopic:3:1,ExampleTopic:1:1,RebalanceTest:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker/certs:/var/private/ssl/certs
+      - ./docker/sasl:/var/private/sasl

--- a/docker/docker-compose.0.10.yml
+++ b/docker/docker-compose.0.10.yml
@@ -2,3 +2,11 @@ version: '2'
 services:
     kafka:
       image: wurstmeister/kafka:0.10.2.1
+      environment:
+        KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
+        KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
+        KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+        KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
+        KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+        KAFKA_SUPER_USERS: "User:admin,User:broker"
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"

--- a/docker/docker-compose.0.11.yml
+++ b/docker/docker-compose.0.11.yml
@@ -4,6 +4,13 @@ services:
       image: wurstmeister/kafka:0.11.0.0
       environment:
         KAFKA_LOG_MESSAGE_FORMAT_VERSION: "0.10.2"
+        KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
+        KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
+        KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+        KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
+        KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+        KAFKA_SUPER_USERS: "User:admin,User:broker"
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"
       volumes:
         - ./docker/start-kafka.sh:/usr/bin/start-kafka.sh
 

--- a/docker/docker-compose.1.0.yml
+++ b/docker/docker-compose.1.0.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+    kafka:
+      image: wurstmeister/kafka:1.0.0
+      environment:
+        KAFKA_LOG_MESSAGE_FORMAT_VERSION: "0.10.2"
+        KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
+        KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
+        KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+        KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
+        KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+        KAFKA_SUPER_USERS: "User:admin,User:broker"
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"
+      volumes:
+        - ./docker/start-kafka.sh:/usr/bin/start-kafka.sh
+

--- a/docker/docker-compose.1.1.yml
+++ b/docker/docker-compose.1.1.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+    kafka:
+      image: wurstmeister/kafka:1.1.0
+      environment:
+        KAFKA_LOG_MESSAGE_FORMAT_VERSION: "0.10.2"
+        KAFKA_LISTENERS: "PLAINTEXT://:9092,SSL://:9093,SASL_PLAINTEXT://:9094"
+        KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,SSL://${KAFKA_ADVERTISED_HOST_NAME}:9093,SASL_PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9094"
+        KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN"
+        KAFKA_SECURITY_INTER_BROKER_PROTOCOL: "PLAINTEXT"
+        KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+        KAFKA_SUPER_USERS: "User:admin,User:broker"
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/sasl/sasl.conf"
+      volumes:
+        - ./docker/start-kafka.sh:/usr/bin/start-kafka.sh
+

--- a/docker/sasl/sasl.conf
+++ b/docker/sasl/sasl.conf
@@ -1,0 +1,9 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+
+    username="broker"
+    password="broker"
+    user_kafkanode="kafkanode"
+    user_admin="admin"
+    user_broker="broker";
+};

--- a/docker/start-kafka.sh
+++ b/docker/start-kafka.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+#
+# FIXME KAFKA_OPTS with the SASL config causes a 'bad substitution' error in
+# the sed commands below. Only seems to impact the 1.x images, not entirely
+# sure why.
+#
+# Swapping KAFKA_OPTS out temporarily lets us work around the issue.
+#
+if [[ -n "$KAFKA_OPTS" ]]; then
+    TEMP_KAFKA_OPTS="$KAFKA_OPTS"
+    unset KAFKA_OPTS
+fi
+
 if [[ -z "$KAFKA_PORT" ]]; then
     export KAFKA_PORT=9092
 fi
@@ -59,4 +71,4 @@ if [[ -n "$CUSTOM_INIT_SCRIPT" ]] ; then
 fi
 
 create-topics.sh &
-exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+KAFKA_OPTS="$TEMP_KAFKA_OPTS" exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties

--- a/lib/client.js
+++ b/lib/client.js
@@ -777,16 +777,8 @@ Client.prototype.handleReceivedData = function (socket) {
 
     var resp = buffer.shallowSlice(0, size);
     var correlationId = resp.readUInt32BE(4);
-    var handlers = this.unqueueCallback(socket, correlationId);
 
-    if (handlers) {
-      var decoder = handlers[0];
-      var cb = handlers[1];
-      var result = decoder(resp);
-      result instanceof Error ? cb.call(this, result) : cb.call(this, null, result);
-    } else {
-      logger.error(`missing handlers for Correlation ID: ${correlationId}`);
-    }
+    this.invokeResponseCallback(socket, correlationId, resp);
     buffer.consume(size);
   } else {
     return;
@@ -798,6 +790,23 @@ Client.prototype.handleReceivedData = function (socket) {
         this.handleReceivedData(socket);
       }.bind(this)
     );
+  }
+};
+
+Client.prototype.invokeResponseCallback = function (socket, correlationId, resp) {
+  var handlers = this.unqueueCallback(socket, correlationId);
+
+  if (handlers) {
+    var decoder = handlers[0];
+    var cb = handlers[1];
+    var result = decoder(resp);
+    if (result instanceof Error) {
+      cb.call(this, result);
+    } else {
+      cb.call(this, null, result);
+    }
+  } else {
+    logger.error(`missing handlers for Correlation ID: ${correlationId}`);
   }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -797,8 +797,7 @@ Client.prototype.invokeResponseCallback = function (socket, correlationId, resp)
   var handlers = this.unqueueCallback(socket, correlationId);
 
   if (handlers) {
-    var decoder = handlers[0];
-    var cb = handlers[1];
+    var [decoder, cb] = handlers;
     var result = decoder(resp);
     if (result instanceof Error) {
       cb.call(this, result);

--- a/lib/client.js
+++ b/lib/client.js
@@ -294,6 +294,11 @@ Client.prototype.sendOffsetRequest = function (payloads, cb) {
 
 Client.prototype.refreshBrokerMetadata = function () {};
 
+Client.prototype.sendWhenReady = function (broker, correlationId, request, decode, cb) {
+  this.queueCallback(broker.socket, correlationId, [decode, cb]);
+  broker.write(request);
+};
+
 Client.prototype.sendGroupRequest = function (encode, decode, requestArgs) {
   requestArgs = _.values(requestArgs);
   var cb = requestArgs.pop();
@@ -309,8 +314,7 @@ Client.prototype.sendGroupRequest = function (encode, decode, requestArgs) {
     return cb(new errors.BrokerNotAvailableError('Broker not available'));
   }
 
-  this.queueCallback(broker.socket, correlationId, [decode, cb]);
-  broker.write(request);
+  this.sendWhenReady(broker, correlationId, request, decode, cb);
 };
 
 Client.prototype.sendGroupCoordinatorRequest = function (groupId, cb) {
@@ -369,8 +373,7 @@ Client.prototype.loadMetadataForTopics = function (topics, cb) {
     return cb(new errors.BrokerNotAvailableError('Broker not available'));
   }
 
-  this.queueCallback(broker.socket, correlationId, [protocol.decodeMetadataResponse, cb]);
-  broker.write(request);
+  this.sendWhenReady(broker, correlationId, request, protocol.decodeMetadataResponse, cb);
 };
 
 Client.prototype.createTopics = function (topics, isAsync, cb) {
@@ -592,8 +595,7 @@ Client.prototype.sendToBroker = function (payloads, encoder, decoder, cb) {
       broker.writeAsync(request);
       cb(null, { result: 'no ack' });
     } else {
-      this.queueCallback(broker.socket, correlationId, [decoder, cb]);
-      broker.write(request);
+      this.sendWhenReady(broker, correlationId, request, decoder, cb);
     }
   }
 };

--- a/lib/errors/SaslAuthenticationError.js
+++ b/lib/errors/SaslAuthenticationError.js
@@ -1,0 +1,20 @@
+var util = require('util');
+
+/**
+ * Thrown when SASL authentication fails for any reason.
+ *
+ * @param {Number} errorCode the error code that caused the error.
+ * @param {String} message A message describing the authentication problem.
+ *
+ * @constructor
+ */
+var SaslAuthenticationError = function (errorCode, message) {
+  Error.captureStackTrace(this, this);
+  this.errorCode = errorCode;
+  this.message = message;
+};
+
+util.inherits(SaslAuthenticationError, Error);
+SaslAuthenticationError.prototype.name = 'SaslAuthenticationError';
+
+module.exports = SaslAuthenticationError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -5,6 +5,7 @@ module.exports = {
   InvalidConsumerOffsetError: require('./InvalidConsumerOffsetError'),
   FailedToRebalanceConsumerError: require('./FailedToRebalanceConsumerError'),
   InvalidConfigError: require('./InvalidConfigError'),
+  SaslAuthenticationError: require('./SaslAuthenticationError'),
   ConsumerGroupErrors: [
     require('./GroupCoordinatorNotAvailableError'),
     require('./GroupLoadInProgressError'),

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -230,12 +230,16 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
     logger.debug('broker socket connected %j', broker);
     clearTimeout(connectTimer);
 
-    this.saslAuth(brokerWrapper, err => {
-      if (err) {
-        return callback(err);
-      }
+    if (this.options.sasl && this.options.sasl.type) {
+      this.saslAuth(brokerWrapper, err => {
+        if (err) {
+          return callback(err);
+        }
+        callback(null, brokerWrapper);
+      });
+    } else {
       callback(null, brokerWrapper);
-    });
+    }
   });
 
   socket.on('error', function (error) {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -656,7 +656,7 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
   async.waterfall(
     [
       callback => {
-        logger.debug(`Sending SASL/${mechanism} handshake request to ${broker.socket.addr}`);
+        logger.debug(`Sending SASL/${mechanism} handshake request to ${broker}`);
 
         const correlationId = this.nextId();
         const request =
@@ -730,7 +730,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
         if (error) {
           logger.error('error initializing broker after connect', error);
           if (error instanceof errors.SaslAuthenticationError) {
-            self.emit('auth_error', error);
+            self.emit('error', error);
           }
         } else {
           const readyEventName = brokerWrapper.getReadyEventName();
@@ -754,7 +754,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
     } else {
       let error = this.error;
       if (!error) {
-        if (socket.saslAuthCorrelationId !== undefined) {
+        if (self.options.sasl && socket.saslAuthCorrelationId !== undefined) {
           delete socket.saslAuthCorrelationId;
           const message = 'Broker closed connection during SASL auth: bad credentials?';
           error = new errors.SaslAuthenticationError(null, message);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -643,6 +643,11 @@ KafkaClient.prototype.initializeBroker = function (broker, callback) {
 
 KafkaClient.prototype.saslAuth = function (broker, callback) {
   const mechanism = this.options.sasl.mechanism.toUpperCase();
+  const apiVersion = broker.apiSupport ? broker.apiSupport.saslHandshake.usable : undefined;
+  if (typeof apiVersion !== 'number') {
+    callback(new errors.SaslAuthenticationError(null, 'Broker does not support SASL authentication'));
+    return;
+  }
 
   async.waterfall(
     [
@@ -651,7 +656,7 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
 
         const correlationId = this.nextId();
         const request =
-          protocol.encodeSaslHandshakeRequest(this.clientId, correlationId, mechanism);
+          protocol.encodeSaslHandshakeRequest(this.clientId, correlationId, apiVersion, mechanism);
 
         this.queueCallback(broker.socket, correlationId, [
           protocol.decodeSaslHandshakeResponse,
@@ -665,12 +670,14 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
         const auth = this.options.sasl;
         const correlationId = this.nextId();
         const request =
-          protocol.encodeSaslAuthenticateRequest(this.clientId, correlationId, auth);
+          protocol.encodeSaslAuthenticateRequest(this.clientId, correlationId, apiVersion, auth);
 
-        this.queueCallback(broker.socket, correlationId, [
-          protocol.decodeSaslAuthenticateResponse,
-          callback
-        ]);
+        let decode = protocol.decodeSaslAuthenticateResponse;
+        if (apiVersion === 0) {
+          decode = _.identity;
+          broker.socket.saslAuthCorrelationId = correlationId;
+        }
+        this.queueCallback(broker.socket, correlationId, [decode, callback]);
         broker.write(request);
       }
     ],
@@ -707,7 +714,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
 
       self.initializeBroker(brokerWrapper, function (error) {
         if (error) {
-          logger.error('error initialize broker after reconnect', error);
+          logger.error('error initializing broker after reconnect', error);
         } else {
           const readyEventName = brokerWrapper.getReadyEventName();
           self.emit(readyEventName);
@@ -717,7 +724,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
     } else {
       self.initializeBroker(brokerWrapper, function (error) {
         if (error) {
-          logger.error('error initialize broker after connect', error);
+          logger.error('error initializing broker after connect', error);
         } else {
           const readyEventName = brokerWrapper.getReadyEventName();
           self.emit(readyEventName);
@@ -738,10 +745,17 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
       logger.debug(`clearing ${this.addr} callback queue without error`);
       self.clearCallbackQueue(this);
     } else {
-      self.clearCallbackQueue(
-        this,
-        this.error != null ? this.error : new errors.BrokerNotAvailableError('Broker not available')
-      );
+      let error = this.error;
+      if (!error) {
+        if (socket.saslAuthCorrelationId !== undefined) {
+          delete socket.saslAuthCorrelationId;
+          const message = 'Broker closed connection during SASL auth: bad credentials?';
+          error = new errors.SaslAuthenticationError(null, message);
+        } else {
+          error = new errors.BrokerNotAvailableError('Broker not available');
+        }
+      }
+      self.clearCallbackQueue(this, error);
     }
     retry(this);
   });
@@ -1177,6 +1191,28 @@ KafkaClient.prototype.sendProduceRequest = function (payloads, requireAcks, ackT
       }
     }
   );
+};
+
+KafkaClient.prototype.handleReceivedData = function (socket) {
+  if (socket.saslAuthCorrelationId !== undefined) {
+    if (socket.buffer.length < 4) {
+      // not enough data yet
+      return;
+    }
+
+    const size = socket.buffer.readInt32BE(0);
+    if (socket.buffer.length - 4 < size) {
+      // still not enough data
+      return;
+    }
+
+    const resp = socket.buffer.slice(4, 4 + size);
+    this.invokeResponseCallback(socket, socket.saslAuthCorrelationId, resp);
+    delete socket.saslAuthCorrelationId;
+    socket.buffer.consume(size + 4);
+  } else {
+    return Client.prototype.handleReceivedData.call(this, socket);
+  }
 };
 
 module.exports = KafkaClient;

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -729,6 +729,9 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
       self.initializeBroker(brokerWrapper, function (error) {
         if (error) {
           logger.error('error initializing broker after connect', error);
+          if (error instanceof errors.SaslAuthenticationError) {
+            self.emit('auth_error', error);
+          }
         } else {
           const readyEventName = brokerWrapper.getReadyEventName();
           self.emit(readyEventName);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -230,7 +230,7 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
     logger.debug('broker socket connected %j', broker);
     clearTimeout(connectTimer);
 
-    if (this.options.sasl && this.options.sasl.type) {
+    if (this.options.sasl && this.options.sasl.mechanism) {
       this.saslAuth(brokerWrapper, err => {
         if (err) {
           return callback(err);
@@ -645,16 +645,16 @@ KafkaClient.prototype.initializeBroker = function (broker, callback) {
 };
 
 KafkaClient.prototype.saslAuth = function (broker, callback) {
+  const mechanism = this.options.sasl.mechanism.toUpperCase();
+
   async.waterfall(
     [
       callback => {
-        const type = this.options.sasl.type.toUpperCase();
-
-        logger.debug(`Sending SASL/${type} handshake request to ${broker.socket.addr}`);
+        logger.debug(`Sending SASL/${mechanism} handshake request to ${broker.socket.addr}`);
 
         const correlationId = this.nextId();
         const request =
-          protocol.encodeSaslHandshakeRequest(this.clientId, correlationId, type);
+          protocol.encodeSaslHandshakeRequest(this.clientId, correlationId, mechanism);
 
         this.queueCallback(broker.socket, correlationId, [
           protocol.decodeSaslHandshakeResponse,
@@ -663,8 +663,7 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
         broker.write(request);
       },
       ([errorCode, enabledMechanisms], callback) => {
-        const type = this.options.sasl.type.toUpperCase();
-        logger.debug(`Sending SASL/${type} authentication request to ${broker.socket.addr}`);
+        logger.debug(`Sending SASL/${mechanism} authentication request to ${broker.socket.addr}`);
 
         const auth = this.options.sasl;
         const correlationId = this.nextId();

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1004,7 +1004,7 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
       callback(null, { result: 'no ack' });
     } else {
       this.queueCallback(broker.socket, correlationId, [decoder, callback]);
-      broker.write(requestData)
+      broker.write(requestData);
     }
   });
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -229,17 +229,7 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
   socket.once('connect', () => {
     logger.debug('broker socket connected %j', broker);
     clearTimeout(connectTimer);
-
-    if (this.options.sasl) {
-      this.saslAuth(brokerWrapper, err => {
-        if (err) {
-          return callback(err);
-        }
-        callback(null, brokerWrapper);
-      });
-    } else {
-      callback(null, brokerWrapper);
-    }
+    callback(null, brokerWrapper);
   });
 
   socket.on('error', function (error) {
@@ -385,8 +375,7 @@ KafkaClient.prototype.loadMetadataFrom = function (broker, cb) {
   var correlationId = this.nextId();
   var request = protocol.encodeMetadataRequest(this.clientId, correlationId, []);
 
-  this.queueCallback(broker.socket, correlationId, [protocol.decodeMetadataResponse, cb]);
-  broker.write(request);
+  this.sendWhenReady(broker, correlationId, request, protocol.decodeMetadataResponse, cb);
 };
 
 KafkaClient.prototype.setBrokerMetadata = function (brokerMetadata) {
@@ -526,8 +515,7 @@ KafkaClient.prototype.getListGroups = function (callback) {
 
       const correlationId = this.nextId();
       const request = protocol.encodeListGroups(this.clientId, correlationId);
-      this.queueCallback(broker.socket, correlationId, [protocol.decodeListGroups, cb]);
-      broker.write(request);
+      this.sendWhenReady(broker, correlationId, request, protocol.decodeListGroups, cb);
     },
     (err, results) => {
       if (err) {
@@ -570,8 +558,7 @@ KafkaClient.prototype.getDescribeGroups = function (groups, callback) {
 
           const correlationId = this.nextId();
           const request = protocol.encodeDescribeGroups(this.clientId, correlationId, groups);
-          this.queueCallback(broker.socket, correlationId, [protocol.decodeDescribeGroups, cb]);
-          broker.write(request);
+          this.sendWhenReady(broker, correlationId, request, protocol.decodeDescribeGroups, cb);
         },
         (err, res) => {
           if (err) {
@@ -640,7 +627,17 @@ KafkaClient.prototype.initializeBroker = function (broker, callback) {
 
     logger.debug('setting api support to %j', versions);
     broker.apiSupport = versions;
-    callback(null);
+
+    if (this.options.sasl) {
+      this.saslAuth(broker, err => {
+        if (err) {
+          return callback(err);
+        }
+        callback(null);
+      });
+    } else {
+      callback(null);
+    }
   });
 };
 
@@ -982,7 +979,7 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
       callback(null, { result: 'no ack' });
     } else {
       this.queueCallback(broker.socket, correlationId, [decoder, callback]);
-      broker.write(requestData);
+      broker.write(requestData)
     }
   });
 
@@ -1123,6 +1120,18 @@ KafkaClient.prototype.sendFetchRequest = function (
     ],
     callback
   );
+};
+
+KafkaClient.prototype.sendWhenReady = function (broker, correlationId, request, decode, cb) {
+  const doSend = () => {
+    this.queueCallback(broker.socket, correlationId, [decode, cb]);
+    broker.write(request);
+  };
+  if (!broker.isReady()) {
+    this.waitUntilReady(broker, doSend);
+  } else {
+    doSend();
+  }
 };
 
 KafkaClient.prototype.sendProduceRequest = function (payloads, requireAcks, ackTimeoutMs, callback) {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -675,6 +675,10 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
       }
     ],
     (error, authBytes) => {
+      if (!error) {
+        broker.authenticated = true;
+      }
+
       // TODO do stuff with authBytes
       callback(error);
     }
@@ -751,7 +755,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   });
   socket.setKeepAlive(true, 60000);
 
-  const brokerWrapper = new BrokerWrapper(socket, this.noAckBatchOptions, this.options.idleConnection);
+  const brokerWrapper = new BrokerWrapper(socket, this.noAckBatchOptions, this.options.idleConnection, this.options.sasl);
 
   function retry (s) {
     if (s.retrying || s.closing) return;
@@ -952,7 +956,7 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
     }
 
     if (!broker.isReady()) {
-      callback(new Error('Broker is not ready (apiSuppport is not set)'));
+      callback(new Error('Broker is not ready'));
       return;
     }
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -230,7 +230,7 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
     logger.debug('broker socket connected %j', broker);
     clearTimeout(connectTimer);
 
-    if (this.options.sasl && this.options.sasl.mechanism) {
+    if (this.options.sasl) {
       this.saslAuth(brokerWrapper, err => {
         if (err) {
           return callback(err);
@@ -662,7 +662,7 @@ KafkaClient.prototype.saslAuth = function (broker, callback) {
         ]);
         broker.write(request);
       },
-      ([errorCode, enabledMechanisms], callback) => {
+      (enabledMechanisms, callback) => {
         logger.debug(`Sending SASL/${mechanism} authentication request to ${broker.socket.addr}`);
 
         const auth = this.options.sasl;

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -229,7 +229,13 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
   socket.once('connect', () => {
     logger.debug('broker socket connected %j', broker);
     clearTimeout(connectTimer);
-    callback(null, brokerWrapper);
+
+    this.saslAuth(brokerWrapper, err => {
+      if (err) {
+        return callback(err);
+      }
+      callback(null, brokerWrapper);
+    });
   });
 
   socket.on('error', function (error) {
@@ -632,6 +638,47 @@ KafkaClient.prototype.initializeBroker = function (broker, callback) {
     broker.apiSupport = versions;
     callback(null);
   });
+};
+
+KafkaClient.prototype.saslAuth = function (broker, callback) {
+  async.waterfall(
+    [
+      callback => {
+        const type = this.options.sasl.type.toUpperCase();
+
+        logger.debug(`Sending SASL/${type} handshake request to ${broker.socket.addr}`);
+
+        const correlationId = this.nextId();
+        const request =
+          protocol.encodeSaslHandshakeRequest(this.clientId, correlationId, type);
+
+        this.queueCallback(broker.socket, correlationId, [
+          protocol.decodeSaslHandshakeResponse,
+          callback
+        ]);
+        broker.write(request);
+      },
+      ([errorCode, enabledMechanisms], callback) => {
+        const type = this.options.sasl.type.toUpperCase();
+        logger.debug(`Sending SASL/${type} authentication request to ${broker.socket.addr}`);
+
+        const auth = this.options.sasl;
+        const correlationId = this.nextId();
+        const request =
+          protocol.encodeSaslAuthenticateRequest(this.clientId, correlationId, auth);
+
+        this.queueCallback(broker.socket, correlationId, [
+          protocol.decodeSaslAuthenticateResponse,
+          callback
+        ]);
+        broker.write(request);
+      }
+    ],
+    (error, authBytes) => {
+      // TODO do stuff with authBytes
+      callback(error);
+    }
+  );
 };
 
 KafkaClient.prototype.createBroker = function (host, port, longpolling) {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -443,7 +443,11 @@ KafkaClient.prototype.brokerForLeader = function (leader, longpolling) {
 
   addr = broker.host + ':' + broker.port;
 
-  return brokers[addr] || this.setupBroker(broker.host, broker.port, longpolling, brokers);
+  return brokers[addr] || this.setupBroker(broker.host, broker.port, longpolling, brokers, err => {
+    if (err) {
+      this.emit('error', err);
+    }
+  });
 };
 
 KafkaClient.prototype.wrapTimeoutIfNeeded = function (socketId, correlationId, callback, overrideTimeout) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -73,7 +73,7 @@ function decodeSaslHandshakeResponse (resp) {
   return [errorCode, mechanisms];
 }
 
-function encodeSaslAuthenticateRequest (clientId, correlationId, authData) {
+function encodeSaslAuthenticateRequest (clientId, correlationId, saslOpts) {
   //
   // FIXME From the Kafka protocol docs:
   //       If SaslHandshakeRequest version is v0, a series of SASL client and server tokens
@@ -82,17 +82,19 @@ function encodeSaslAuthenticateRequest (clientId, correlationId, authData) {
   //       SaslAuthenticate request/response are used, where the actual SASL tokens are
   //       wrapped in the Kafka protocol.
   //
+  var username = saslOpts.username || '';
+  var password = saslOpts.password || '';
   var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslAuthenticate, 0);
-  if (authData.type.toUpperCase() === 'PLAIN') {
+  if (saslOpts.mechanism.toUpperCase() === 'PLAIN') {
     var authBytes =
       (new Buffermaker())
-        .string(authData.authzid).Int8(0)
-        .string(authData.username).Int8(0)
-        .string(authData.password)
+        .string(username).Int8(0)
+        .string(username).Int8(0)
+        .string(password)
         .make();
     request.Int32BE(authBytes.length).string(authBytes);
   } else {
-    return new Error('unsupported SASL auth type: ' + authData.type.toUpperCase());
+    return new Error('unsupported SASL auth type: ' + saslOpts.mechanism.toUpperCase());
   }
   return encodeRequestWithLength(request.make());
 }

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -39,8 +39,8 @@ function encodeRequestHeader (clientId, correlationId, apiKey, apiVersion) {
     .string(clientId);
 }
 
-function encodeSaslHandshakeRequest (clientId, correlationId, mechanism) {
-  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslHandshake, 1);
+function encodeSaslHandshakeRequest (clientId, correlationId, apiVersion, mechanism) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslHandshake, apiVersion);
   request.Int16BE(mechanism.length).string(mechanism.toUpperCase());
   return encodeRequestWithLength(request.make());
 }
@@ -76,7 +76,7 @@ function decodeSaslHandshakeResponse (resp) {
   return new SaslAuthenticationError(errorCode, 'Handshake failed.');
 }
 
-function encodeSaslAuthenticateRequest (clientId, correlationId, saslOpts) {
+function encodeSaslAuthenticateRequest (clientId, correlationId, apiVersion, saslOpts) {
   //
   // FIXME From the Kafka protocol docs:
   //       If SaslHandshakeRequest version is v0, a series of SASL client and server tokens
@@ -87,18 +87,24 @@ function encodeSaslAuthenticateRequest (clientId, correlationId, saslOpts) {
   //
   var username = saslOpts.username || '';
   var password = saslOpts.password || '';
-  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslAuthenticate, 0);
+  var authBytes = null;
   if (saslOpts.mechanism.toUpperCase() === 'PLAIN') {
-    var authBytes =
+    authBytes =
       (new Buffermaker())
         .string(username).Int8(0)
         .string(username).Int8(0)
         .string(password)
         .make();
-    request.Int32BE(authBytes.length).string(authBytes);
   } else {
     return new Error('unsupported SASL auth type: ' + saslOpts.mechanism.toUpperCase());
   }
+
+  if (apiVersion === 0) {
+    return encodeRequestWithLength(authBytes);
+  }
+
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslAuthenticate, 0);
+  request.Int32BE(authBytes.length).string(authBytes);
   return encodeRequestWithLength(request.make());
 }
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -12,6 +12,7 @@ var GROUP_ERROR = protocol.GROUP_ERROR;
 var PartitionMetadata = protocol.PartitionMetadata;
 const API_KEY_TO_NAME = _.invert(REQUEST_TYPE);
 const MessageSizeTooLarge = require('../errors/MessageSizeTooLargeError');
+const SaslAuthenticationError = require('../errors/SaslAuthenticationError');
 
 var API_VERSION = 0;
 var REPLICA_ID = -1;
@@ -69,8 +70,10 @@ function decodeSaslHandshakeResponse (resp) {
         mechanisms.push(vars.mechanism);
       });
   }
-
-  return [errorCode, mechanisms];
+  if (errorCode == null || errorCode === 0) {
+    return mechanisms;
+  }
+  return new SaslAuthenticationError(errorCode, 'Handshake failed.');
 }
 
 function encodeSaslAuthenticateRequest (clientId, correlationId, saslOpts) {
@@ -118,7 +121,10 @@ function decodeSaslAuthenticateResponse (resp) {
       this.buffer('authBytes', vars.authBytesLength);
       authBytes = vars.authBytes.toString();
     });
-  return [errorCode, errorMessage, authBytes];
+  if (errorCode == null || errorCode === 0) {
+    return authBytes;
+  }
+  return new SaslAuthenticationError(errorCode, errorMessage);
 }
 
 function encodeFetchRequest (maxWaitMs, minBytes) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -38,6 +38,87 @@ function encodeRequestHeader (clientId, correlationId, apiKey, apiVersion) {
     .string(clientId);
 }
 
+function encodeSaslHandshakeRequest (clientId, correlationId, mechanism) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslHandshake, 1);
+  request.Int16BE(mechanism.length).string(mechanism.toUpperCase());
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeSaslHandshakeResponse (resp) {
+  var mechanisms = [];
+  var errorCode = null;
+
+  Binary.parse(resp)
+    .word32bs('size')
+    .word32bs('correlationId')
+    .word16bs('errorCode')
+    .tap(function (vars) {
+      errorCode = vars.errorCode;
+    })
+    .word32bs('numMechanisms')
+    .loop(_decodeMechanisms);
+
+  function _decodeMechanisms (end, vars) {
+    if (vars.numMechanisms-- === 0) {
+      return end();
+    }
+    this
+      .word16be('mechanismSize')
+      .tap(function (vars) {
+        this.buffer('mechanism', vars.mechanismSize);
+        mechanisms.push(vars.mechanism);
+      });
+  }
+
+  return [errorCode, mechanisms];
+}
+
+function encodeSaslAuthenticateRequest (clientId, correlationId, authData) {
+  //
+  // FIXME From the Kafka protocol docs:
+  //       If SaslHandshakeRequest version is v0, a series of SASL client and server tokens
+  //       corresponding to the mechanism are sent as opaque packets without wrapping the
+  //       messages with Kafka protocol headers. If SaslHandshakeRequest version is v1, the
+  //       SaslAuthenticate request/response are used, where the actual SASL tokens are
+  //       wrapped in the Kafka protocol.
+  //
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.saslAuthenticate, 0);
+  if (authData.type.toUpperCase() === 'PLAIN') {
+    var authBytes =
+      (new Buffermaker())
+        .string(authData.authzid).Int8(0)
+        .string(authData.username).Int8(0)
+        .string(authData.password)
+        .make();
+    request.Int32BE(authBytes.length).string(authBytes);
+  } else {
+    return new Error('unsupported SASL auth type: ' + authData.type.toUpperCase());
+  }
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeSaslAuthenticateResponse (resp) {
+  var errorCode = null;
+  var errorMessage = null;
+  var authBytes = null;
+  Binary.parse(resp)
+    .word32bs('size')
+    .word32bs('correlationId')
+    .word16bs('errorCode')
+    .word16bs('errorMessageLength')
+    .tap(function (vars) {
+      errorCode = vars.errorCode;
+      this.buffer('errorMessage', vars.errorMessageLength);
+      errorMessage = vars.errorMessage.toString();
+    })
+    .word32bs('authBytesLength')
+    .tap(function (vars) {
+      this.buffer('authBytes', vars.authBytesLength);
+      authBytes = vars.authBytes.toString();
+    });
+  return [errorCode, errorMessage, authBytes];
+}
+
 function encodeFetchRequest (maxWaitMs, minBytes) {
   return function encodeFetchRequest (clientId, correlationId, payloads) {
     return _encodeFetchRequest(clientId, correlationId, payloads, maxWaitMs, minBytes);
@@ -1404,6 +1485,11 @@ function decodeVersionsResponse (resp) {
     });
   return error || versions;
 }
+
+exports.encodeSaslHandshakeRequest = encodeSaslHandshakeRequest;
+exports.decodeSaslHandshakeResponse = decodeSaslHandshakeResponse;
+exports.encodeSaslAuthenticateRequest = encodeSaslAuthenticateRequest;
+exports.decodeSaslAuthenticateResponse = decodeSaslAuthenticateResponse;
 
 exports.encodeFetchRequest = encodeFetchRequest;
 exports.decodeFetchResponse = decodeFetchResponse;

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -43,7 +43,8 @@ const API_MAP = {
   saslHandshake: null,
   apiVersions: [[p.encodeVersionsRequest, p.decodeVersionsResponse]],
   createTopics: null,
-  deleteTopics: null
+  deleteTopics: null,
+  saslAuthenticate: null
 };
 
 // Since versions API isn't around until 0.10 we need to hardcode the supported API versions for 0.9 here

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -40,11 +40,14 @@ const API_MAP = {
   syncGroup: [[p.encodeJoinGroupRequest, p.decodeJoinGroupResponse]],
   describeGroups: [[p.encodeDescribeGroups, p.decodeDescribeGroups]],
   listGroups: [[p.encodeListGroups, p.decodeListGroups]],
-  saslHandshake: null,
+  saslHandshake: [
+    [p.encodeSaslHandshakeRequest, p.decodeSaslHandshakeResponse],
+    [p.encodeSaslHandshakeRequest, p.decodeSaslHandshakeResponse]
+  ],
   apiVersions: [[p.encodeVersionsRequest, p.decodeVersionsResponse]],
   createTopics: null,
   deleteTopics: null,
-  saslAuthenticate: null
+  saslAuthenticate: [[p.encodeSaslAuthenticationRequest, p.decodeSaslAuthenticationResponse]]
 };
 
 // Since versions API isn't around until 0.10 we need to hardcode the supported API versions for 0.9 here

--- a/lib/protocol/protocol_struct.js
+++ b/lib/protocol/protocol_struct.js
@@ -87,7 +87,8 @@ var REQUEST_TYPE = {
   saslHandshake: 17,
   apiVersions: 18,
   createTopics: 19,
-  deleteTopics: 20
+  deleteTopics: 20,
+  saslAuthenticate: 36
 };
 
 Object.keys(KEYS).forEach(function (o) {

--- a/lib/wrapper/BrokerWrapper.js
+++ b/lib/wrapper/BrokerWrapper.js
@@ -6,10 +6,12 @@ var BrokerTransform = require('./BrokerTransform');
 const util = require('util');
 const EventEmitter = require('events');
 
-var BrokerWrapper = function (socket, noAckBatchOptions, idleConnectionMs) {
+var BrokerWrapper = function (socket, noAckBatchOptions, idleConnectionMs, needAuthentication) {
   EventEmitter.call(this);
   this.socket = socket;
   this.idleConnectionMs = idleConnectionMs;
+  this.needAuthentication = !!needAuthentication;
+  this.authenticated = false;
 
   var self = this;
   var readable = new BrokerReadable();
@@ -41,7 +43,7 @@ BrokerWrapper.prototype.isConnected = function () {
 };
 
 BrokerWrapper.prototype.isReady = function () {
-  return this.apiSupport != null;
+  return this.apiSupport != null && (!this.needAuthentication || this.authenticated);
 };
 
 BrokerWrapper.prototype.isIdle = function () {

--- a/lib/wrapper/BrokerWrapper.js
+++ b/lib/wrapper/BrokerWrapper.js
@@ -62,7 +62,15 @@ BrokerWrapper.prototype.writeAsync = function (buffer) {
 BrokerWrapper.prototype.toString = function () {
   return `[${this.constructor.name} ${
     this.socket.addr
-  } (connected: ${this.isConnected()}) (ready: ${this.isReady()}) (idle: ${this.isIdle()})]`;
+  } (connected: ${this.isConnected()}) (ready: ${
+    this.isReady()
+  }) (idle: ${
+    this.isIdle()
+  }) (needAuthentication: ${
+    this.needAuthentication
+  }) (authenticated: ${
+    this.authenticated
+  })]`;
 };
 
 module.exports = BrokerWrapper;

--- a/test/test.client.js
+++ b/test/test.client.js
@@ -29,7 +29,7 @@ describe('Client', function () {
 
     it('should always consume entire response even if handlers are missing', function () {
       const fakeClient = {
-        unqueueCallback: sinon.stub().returns(null)
+        invokeResponseCallback: sinon.stub().returns(null)
       };
 
       sinon.spy(socket.buffer, 'consume');
@@ -42,13 +42,13 @@ describe('Client', function () {
       Client.prototype.handleReceivedData.call(fakeClient, socket);
       sinon.assert.calledOnce(socket.buffer.shallowSlice);
       sinon.assert.calledOnce(socket.buffer.consume);
-      sinon.assert.calledOnce(fakeClient.unqueueCallback);
+      sinon.assert.calledOnce(fakeClient.invokeResponseCallback);
       should(socket.waiting).be.empty;
     });
 
     it('should consume entire response if handlers are missing and set waiting to false for longpolling sockets', function () {
       const fakeClient = {
-        unqueueCallback: sinon.stub().returns(null)
+        invokeResponseCallback: sinon.stub().returns(null)
       };
 
       sinon.spy(socket.buffer, 'consume');
@@ -64,21 +64,29 @@ describe('Client', function () {
       Client.prototype.handleReceivedData.call(fakeClient, socket);
       sinon.assert.calledOnce(socket.buffer.shallowSlice);
       sinon.assert.calledOnce(socket.buffer.consume);
-      sinon.assert.calledOnce(fakeClient.unqueueCallback);
+      sinon.assert.calledOnce(fakeClient.invokeResponseCallback);
       socket.waiting.should.be.false;
     });
 
     it('should early return when buffer is beyond offset', function () {
+      const fakeClient = {
+        invokeResponseCallback: function () {}
+      };
+
       socket.buffer.append(Uint8Array.from([0, 0, 0]));
 
       const readSpy = sinon.spy(socket.buffer, 'readUInt32BE');
-      Client.prototype.handleReceivedData.call({}, socket);
+      Client.prototype.handleReceivedData.call(fakeClient, socket);
       sinon.assert.notCalled(readSpy);
     });
 
     it('should early return when buffer is empty', function () {
+      const fakeClient = {
+        invokeResponseCallback: function () {}
+      };
+
       const readSpy = sinon.spy(socket.buffer, 'readUInt32BE');
-      Client.prototype.handleReceivedData.call({}, socket);
+      Client.prototype.handleReceivedData.call(fakeClient, socket);
       sinon.assert.notCalled(readSpy);
     });
   });

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -540,13 +540,8 @@ describe('Kafka Client', function () {
             retries: 0
           }
         });
-        client.once('error', function (err) {
-          // TODO check for error codes etc. if available
-          if (err instanceof SaslAuthenticationError) {
-            done();
-            return;
-          }
-          done(err);
+        client.once('auth_error', function (err) {
+          done();
         });
         client.once('ready', function () {
           var err = new Error('expected error!');

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -470,7 +470,7 @@ describe('Kafka Client', function () {
         connectRetryOptions: {
           retries: 0
         },
-        kafkaHost: 'localhost:9094'
+        kafkaHost: 'localhost:9095'
       });
 
       client.on('error', function (error) {

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -502,6 +502,9 @@ describe('Kafka Client', function () {
           mechanism: 'plain',
           username: 'kafkanode',
           password: 'kafkanode'
+        },
+        connectRetryOptions: {
+          retries: 0
         }
       });
       client.once('error', done);
@@ -509,6 +512,32 @@ describe('Kafka Client', function () {
         client.ready.should.be.true;
         client.brokerMetadata.should.not.be.empty;
         done();
+      });
+    });
+
+    it('should not connect SASL/PLAIN with bad credentials', function (done) {
+      client = new Client({
+        kafkaHost: 'localhost:9094',
+        sasl: {
+          mechanism: 'plain',
+          username: 'kafkanode',
+          password: 'badpasswd'
+        },
+        connectRetryOptions: {
+          retries: 0
+        }
+      });
+      client.once('error', function (err) {
+        // we expect a SaslAuthenticationError with code 58
+        if (err.errorCode !== 58) {
+          done(err);
+          return;
+        }
+        done();
+      });
+      client.once('ready', function () {
+        var err = new Error('expected error!');
+        done(err);
       });
     });
   });

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -540,8 +540,13 @@ describe('Kafka Client', function () {
             retries: 0
           }
         });
-        client.once('auth_error', function () {
-          done();
+        client.once('error', function (err) {
+          if (err instanceof SaslAuthenticationError) {
+            // expected
+            done();
+          } else {
+            done(err);
+          }
         });
         client.once('ready', function () {
           var err = new Error('expected error!');

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -494,6 +494,23 @@ describe('Kafka Client', function () {
         done();
       });
     });
+
+    it('should connect SASL/PLAIN', function (done) {
+      client = new Client({
+        kafkaHost: 'localhost:9094',
+        sasl: {
+          mechanism: 'plain',
+          username: 'kafkanode',
+          password: 'kafkanode'
+        }
+      });
+      client.once('error', done);
+      client.once('ready', function () {
+        client.ready.should.be.true;
+        client.brokerMetadata.should.not.be.empty;
+        done();
+      });
+    });
   });
 
   describe('#updateMetadatas', function () {

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -496,49 +496,51 @@ describe('Kafka Client', function () {
       });
     });
 
-    it('should connect SASL/PLAIN', function (done) {
-      client = new Client({
-        kafkaHost: 'localhost:9094',
-        sasl: {
-          mechanism: 'plain',
-          username: 'kafkanode',
-          password: 'kafkanode'
-        },
-        connectRetryOptions: {
-          retries: 0
-        }
-      });
-      client.once('error', done);
-      client.once('ready', function () {
-        client.ready.should.be.true;
-        client.brokerMetadata.should.not.be.empty;
-        done();
-      });
-    });
-
-    it('should not connect SASL/PLAIN with bad credentials', function (done) {
-      client = new Client({
-        kafkaHost: 'localhost:9094',
-        sasl: {
-          mechanism: 'plain',
-          username: 'kafkanode',
-          password: 'badpasswd'
-        },
-        connectRetryOptions: {
-          retries: 0
-        }
-      });
-      client.once('error', function (err) {
-        // TODO check for error codes etc. if available
-        if (err instanceof SaslAuthenticationError) {
+    describe('using SASL authentication', function () {
+      it('should connect SASL/PLAIN', function (done) {
+        client = new Client({
+          kafkaHost: 'localhost:9094',
+          sasl: {
+            mechanism: 'plain',
+            username: 'kafkanode',
+            password: 'kafkanode'
+          },
+          connectRetryOptions: {
+            retries: 0
+          }
+        });
+        client.once('error', done);
+        client.once('ready', function () {
+          client.ready.should.be.true;
+          client.brokerMetadata.should.not.be.empty;
           done();
-          return;
-        }
-        done(err);
+        });
       });
-      client.once('ready', function () {
-        var err = new Error('expected error!');
-        done(err);
+
+      it('should not connect SASL/PLAIN with bad credentials', function (done) {
+        client = new Client({
+          kafkaHost: 'localhost:9094',
+          sasl: {
+            mechanism: 'plain',
+            username: 'kafkanode',
+            password: 'badpasswd'
+          },
+          connectRetryOptions: {
+            retries: 0
+          }
+        });
+        client.once('error', function (err) {
+          // TODO check for error codes etc. if available
+          if (err instanceof SaslAuthenticationError) {
+            done();
+            return;
+          }
+          done(err);
+        });
+        client.once('ready', function () {
+          var err = new Error('expected error!');
+          done(err);
+        });
       });
     });
   });

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const TimeoutError = require('../lib/errors/TimeoutError');
 const TopicsNotExistError = require('../lib/errors/TopicsNotExistError');
 const NotControllerError = require('../lib/errors/NotControllerError');
+const SaslAuthenticationError = require('../lib/errors/SaslAuthenticationError');
 const BrokerWrapper = require('../lib/wrapper/BrokerWrapper');
 const FakeSocket = require('./mocks/mockSocket');
 const should = require('should');
@@ -528,12 +529,12 @@ describe('Kafka Client', function () {
         }
       });
       client.once('error', function (err) {
-        // we expect a SaslAuthenticationError with code 58
-        if (err.errorCode !== 58) {
-          done(err);
+        // TODO check for error codes etc. if available
+        if (err instanceof SaslAuthenticationError) {
+          done();
           return;
         }
-        done();
+        done(err);
       });
       client.once('ready', function () {
         var err = new Error('expected error!');

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -540,7 +540,7 @@ describe('Kafka Client', function () {
             retries: 0
           }
         });
-        client.once('auth_error', function (err) {
+        client.once('auth_error', function () {
           done();
         });
         client.once('ready', function () {

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -497,6 +497,17 @@ describe('Kafka Client', function () {
     });
 
     describe('using SASL authentication', function () {
+      before(function () {
+        // these tests should not run again Kafka 0.8 & 0.9
+        const supportsSaslPlain =
+          !process.env.KAFKA_VERSION ||
+          (process.env.KAFKA_VERSION !== '0.8' &&
+           process.env.KAFKA_VERSION !== '0.9');
+        if (!supportsSaslPlain) {
+          this.skip();
+        }
+      });
+
       it('should connect SASL/PLAIN', function (done) {
         client = new Client({
           kafkaHost: 'localhost:9094',


### PR DESCRIPTION
Still plenty more to do here (honestly, it's a bit of a mess in places), but thought I might open this up for comment.

We have a pressing need for dumb authentication in our Kafka cluster(s) to work around some infrastructure issues and kafka-node's support for TLS client certs isn't an option in the short term. Our immediate needs would be met with basic support for SASL/PLAIN, but obviously kafka-node doesn't support SASL -- just wanted to prove to myself that it was fairly trivial to hook up something simple. So this is my whirlwind prototype.

Very, very briefly verified against a local Kafka instance configured with a SASL_PLAINTEXT listener, seems to work -- just barely. 😅 

Support for SASL/GSSAPI & SASL/SCRAM-SHA-{256,512} are lower on my list of priorities, but would look pretty similar.

Previous discussion by others back in 2016 over in #511 and #482. Hopefully SASL support is still something you're open to @hyperlink.
