### PR TITLE
Validate joinGroupResponse has some required elements

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -253,6 +253,10 @@ ConsumerGroup.prototype.assignPartitions = function (protocol, groupMembers, cal
   logger.debug('Using group protocol', protocol);
 
   protocol = _.find(this.protocols, { name: protocol });
+  if (!protocol) {
+    callback(new Error('Unknown group protocol: ' + protocol));
+    return;
+  }
 
   var self = this;
   var topics = _(groupMembers).map('subscription').flatten().uniq().value();
@@ -280,6 +284,10 @@ function mapTopicToPartitions (metadata) {
 
 ConsumerGroup.prototype.handleJoinGroup = function (joinGroupResponse, callback) {
   logger.debug('joinGroupResponse %j from %s', joinGroupResponse, this.client.clientId);
+  if (!joinGroupResponse.memberId || !joinGroupResponse.generationId) {
+    callback(new Error('Invalid joinGroupResponse: ' + JSON.stringify(joinGroupResponse)));
+    return;
+  }
 
   this.isLeader = joinGroupResponse.leaderId === joinGroupResponse.memberId;
   this.generationId = joinGroupResponse.generationId;


### PR DESCRIPTION
If the response is missing key elements, or sends an invalid protocol,
we need to error out. Invalid protocols before was throwing JS errors.

I'm not sure WHY I had this occur, but I had processes crashing in production due to this.