### PR TITLE
Update docs to specifiy sslOptions in kafkaClient options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ New KafkaClient connects directly to Kafka brokers instead of connecting to zook
 * `connectRetryOptions` : object hash that applies to the initial connection. see [retry](https://www.npmjs.com/package/retry) module for these options.
 * `idleConnection` : allows the broker to disconnect an idle connection from a client (otherwise the clients continues to reconnect after being disconnected). The value is elapsed time in ms without any data written to the TCP socket. default: 5 minutes
 * `maxAsyncRequests` : maximum async operations at a time toward the kafka cluster. default: 10
+* `sslOptions`: **Object**, options to be passed to the tls broker sockets, ex. { rejectUnauthorized: false } (Kafka +0.9)
 
 ### Example
 


### PR DESCRIPTION
I added SSL to the options for the KafkaClient API. I assume they are only for Kafka 0.9+ like they are for the Client API.

I'd also like to make it explicit that they are being passed straight to the Node TLS module so users can get a full list of things they can set on the object, but I'm not sure if Client is handling that like KafkaClient seems to be.