### PR TITLE
Add support for Buffers as keys, which is useful for Avro encoded keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ var kafka = require('kafka-node'),
 {
    topic: 'topicName',
    messages: ['message body'], // multi messages should be a array, single message can be just a string or a KeyedMessage instance
-   key: 'theKey', // only needed when using keyed partitioner
+   key: 'theKey', // string or buffer, only needed when using keyed partitioner
    partition: 0, // default 0
    attributes: 2, // default: 0
    timestamp: Date.now() // <-- defaults to Date.now() (only available with kafka v0.10 and KafkaClient only)
@@ -241,7 +241,7 @@ var kafka = require('kafka-node'),
 {
    topic: 'topicName',
    messages: ['message body'], // multi messages should be a array, single message can be just a string,
-   key: 'theKey', // only needed when using keyed partitioner
+   key: 'theKey', // string or buffer, only needed when using keyed partitioner
    attributes: 1,
    timestamp: Date.now() // <-- defaults to Date.now() (only available with kafka v0.10 and KafkaClient only)
 }

--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -45,10 +45,11 @@ util.inherits(KeyedPartitioner, Partitioner);
 
 // Taken from oid package (Dan Bornstein)
 // Copyright The Obvious Corporation.
-KeyedPartitioner.prototype.hashCode = function (string) {
+KeyedPartitioner.prototype.hashCode = function (stringOrBuffer) {
   let hash = 0;
-  if (string) {
-    const length = string.toString().length;
+  if (stringOrBuffer) {
+    const string = stringOrBuffer.toString();
+    const length = string.length;
 
     for (let i = 0; i < length; i++) {
       hash = ((hash * 31) + string.charCodeAt(i)) & 0x7fffffff;

--- a/test/test.partitioner.js
+++ b/test/test.partitioner.js
@@ -79,6 +79,13 @@ describe('Partitioner', function () {
         partitions[0].should.equal(1);
         partitions[1].should.equal(0);
       });
+
+      it('should return partitions based on a given buffer', function () {
+        var partitions = [partitioner.getPartition([0, 1, 2], Buffer.from([5, 4, 3, 2])), partitioner.getPartition([0, 1, 2], Buffer.from([3, 2, 1, 0]))];
+        partitions.should.have.length(2);
+        partitions[0].should.equal(2);
+        partitions[1].should.equal(0);
+      });
     });
   });
 


### PR DESCRIPTION
This adds support for using Buffers as keys. Earlier in _hashCode()_ it tried to do _string.charCodeAt_ which failed if the variable was a Buffer. But in my patch it simply does _.toString()_ first. This is needed when having Avro encoded keys for example, which we use in our project.