### PR TITLE
Do not attempt to refreshBrokerMetadata when client is closing

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -301,7 +301,7 @@ KafkaClient.prototype.refreshBrokers = function () {
 };
 
 KafkaClient.prototype.refreshBrokerMetadata = function (callback) {
-  if (this.refreshingMetadata) {
+  if (this.refreshingMetadata || this.closing) {
     return;
   }
 

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -712,6 +712,22 @@ describe('Kafka Client', function () {
       sinon.assert.notCalled(client.updateMetadatas);
       sinon.assert.notCalled(client.refreshBrokers);
     });
+
+    it('should not perform refreshBrokerMetadata if consumer is closing', function () {
+      sandbox.stub(client, 'getAvailableBroker');
+      sandbox.stub(client, 'loadMetadataFrom');
+      sandbox.stub(client, 'updateMetadatas');
+      sandbox.stub(client, 'refreshBrokers');
+      client.closing = true;
+
+      client.refreshBrokerMetadata();
+
+      client.closing.should.be.true;
+      sinon.assert.notCalled(client.getAvailableBroker);
+      sinon.assert.notCalled(client.loadMetadataFrom);
+      sinon.assert.notCalled(client.updateMetadatas);
+      sinon.assert.notCalled(client.refreshBrokers);
+    });
   });
 
   describe('Verify Timeout', function () {


### PR DESCRIPTION
this should help with some of the intermittent failures.