### PR TITLE
Yield error if apiSupport is empty on a ensured ready broker

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -561,6 +561,11 @@ KafkaClient.prototype.initializeBroker = function (broker, callback) {
     } else {
       logger.debug(`Received versions response from ${broker.socket.addr}`);
     }
+
+    if (_.isEmpty(versions)) {
+      return callback(new Error(`getApiVersions response was empty for broker: ${broker}`));
+    }
+
     logger.debug('setting api support to %j', versions);
     broker.apiSupport = versions;
     callback(null);
@@ -774,6 +779,11 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
       return;
     }
 
+    if (!broker.isReady()) {
+      callback(new Error('Broker is not ready (apiSuppport is not set)'));
+      return;
+    }
+
     const coder = getSupportedForRequestType(broker, request.type);
 
     const encoder = request.data.args != null ? coder.encoder.apply(null, request.data.args) : coder.encoder;
@@ -793,7 +803,7 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
 
   const ensureBrokerReady = async.ensureAsync((leader, callback) => {
     const broker = this.brokerForLeader(leader);
-    if (broker.apiSupport == null) {
+    if (!broker.isReady()) {
       logger.debug('missing apiSupport waiting until broker is ready...');
       this.waitUntilReady(broker, callback);
     } else {

--- a/lib/wrapper/BrokerWrapper.js
+++ b/lib/wrapper/BrokerWrapper.js
@@ -40,6 +40,10 @@ BrokerWrapper.prototype.isConnected = function () {
   return !this.socket.destroyed && !this.socket.closing && !this.socket.error;
 };
 
+BrokerWrapper.prototype.isReady = function () {
+  return this.apiSupport != null;
+};
+
 BrokerWrapper.prototype.isIdle = function () {
   return Date.now() - this._lastWrite >= this.idleConnectionMs;
 };
@@ -51,6 +55,12 @@ BrokerWrapper.prototype.write = function (buffer) {
 
 BrokerWrapper.prototype.writeAsync = function (buffer) {
   this.readableSocket.push(buffer);
+};
+
+BrokerWrapper.prototype.toString = function () {
+  return `[${this.constructor.name} ${
+    this.socket.addr
+  } (connected: ${this.isConnected()}) (ready: ${this.isReady()}) (idle: ${this.isIdle()})]`;
 };
 
 module.exports = BrokerWrapper;


### PR DESCRIPTION
It's possible to get a synchronous exception if `apiSupport` is empty for some reason. We should yield an error explicitly in this case.