### PR TITLE
Add create topics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,29 +183,34 @@ producer.on('error', function (err) {})
 ```
 > ⚠️**WARNING**: Batch multiple messages of the same topic/partition together as an array on the `messages` attribute otherwise you may lose messages!
 
-### createTopics(topics, async, cb)
-This method is used to create topics on the Kafka server. It only works when `auto.create.topics.enable`, on the Kafka server, is set to true. Our client simply sends a metadata request to the server which will auto create topics. When `async` is set to false, this method does not return until all topics are created, otherwise it returns immediately.
+### createTopics(topics, cb)
+This method is used to create topics on the Kafka server. It requires Kafka 0.10+.
 
 * `topics`: **Array**, array of topics
-* `async`: **Boolean**, async or sync
 * `cb`: **Function**, the callback
 
 Example:
 
 ``` js
-var kafka = require('kafka-node'),
-    Producer = kafka.Producer,
-    client = new kafka.Client(),
-    producer = new Producer(client);
-// Create topics sync
-producer.createTopics(['t','t1'], false, function (err, data) {
-    console.log(data);
-});
-// Create topics async
-producer.createTopics(['t'], true, function (err, data) {});
-producer.createTopics(['t'], function (err, data) {});// Simply omit 2nd arg
-```
+var kafka = require('kafka-node');
+var client = new kafka.KafkaClient();
 
+var topicsToCreate = [{
+  topic: 'topic1',
+  partitions: 1,
+  replicationFactor: 2
+},
+{
+  topic: 'topic2',
+  partitions: 5,
+  replicationFactor: 3
+}];
+
+client.createTopics(topics, (error, result) => {
+  // result is an array of any errors if a given topic could not be created 
+});
+
+```
 
 ## HighLevelProducer
 ### HighLevelProducer(client, [options], [customPartitioner])

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -42,4 +42,12 @@ Admin.prototype.describeGroups = function (consumerGroups, cb) {
   this.client.getDescribeGroups(consumerGroups, cb);
 };
 
+Admin.prototype.createTopics = function (topics, cb) {
+  if (!this.ready) {
+    this.once('ready', () => this.client.createTopics(topics, cb));
+    return;
+  }
+  this.client.createTopics(topics, cb);
+};
+
 module.exports = Admin;

--- a/lib/errors/NotControllerError.js
+++ b/lib/errors/NotControllerError.js
@@ -1,0 +1,18 @@
+var util = require('util');
+
+/**
+ * The request was sent to a broker that was not the controller.
+ *
+ * @param {*} message A message describing the issue.
+ *
+ * @constructor
+ */
+var NotController = function (message) {
+  Error.captureStackTrace(this, this);
+  this.message = message;
+};
+
+util.inherits(NotController, Error);
+NotController.prototype.name = 'NotController';
+
+module.exports = NotController;

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -241,6 +241,31 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
   }, timeout);
 };
 
+KafkaClient.prototype.getController = function (callback) {
+  this.loadMetadataForTopicsV2([], (error, result) => {
+    if (error) {
+      return callback(error);
+    }
+
+    var controllerId = result[1].clusterMetadata.controllerId;
+    var controllerMetadata = result[0][controllerId];
+    var broker = this.getBroker(controllerMetadata.host, controllerMetadata.port);
+
+    if (!broker || !broker.isConnected()) {
+      return callback(new errors.BrokerNotAvailableError('Controller broker not available'));
+    }
+
+    return callback(null, broker);
+  });
+};
+
+KafkaClient.prototype.getBroker = function (host, port, longpolling) {
+  const brokers = this.getBrokers();
+
+  var addr = host + ':' + port;
+  return brokers[addr] || this.setupBroker(host, port, longpolling, brokers);
+};
+
 KafkaClient.prototype.setupBroker = function (host, port, longpolling, brokers) {
   var brokerKey = host + ':' + port;
   brokers[brokerKey] = this.createBroker(host, port, longpolling);
@@ -691,6 +716,29 @@ KafkaClient.prototype.clearCallbackQueue = function (socket, error) {
     });
   }
   delete this.cbqueue[socketId];
+};
+
+// Sends a version 1 metadata request which includes controller node in response
+KafkaClient.prototype.loadMetadataForTopicsV2 = function (topics, cb) {
+  var correlationId = this.nextId();
+  var request = protocol.encodeMetadataV1Request(this.clientId, correlationId, topics);
+  var broker = this.brokerForLeader();
+
+  this.queueCallback(broker.socket, correlationId, [protocol.decodeMetadataV1Response, cb]);
+  broker.write(request);
+};
+
+KafkaClient.prototype.createTopicsV2 = function (topics, cb) {
+  var correlationId = this.nextId();
+  var request = protocol.encodeCreateTopicRequest(this.clientId, correlationId, topics, this.options.requestTimeout);
+  this.getController((error, broker) => {
+    if (error) {
+      return cb(error);
+    }
+
+    this.queueCallback(broker.socket, correlationId, [protocol.decodeCreateTopicResponse, cb]);
+    broker.write(request);
+  });
 };
 
 KafkaClient.prototype.topicExists = function (topics, callback) {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -790,21 +790,21 @@ KafkaClient.prototype.loadMetadataForTopics = function (topics, callback) {
       broker.write(request);
     }
   ], (err, result) => {
-    if (!err) {
-      this.updateMetadatas(result[1]);
-    }
-
     callback(err, result[1]);
   });
 };
 
 /**
  * Creates one or more topics.
- * Requires kafka 0.10 or greater.
  * @param {Array} topics Array of topics with partition and replication factor to create.
  * @param {createTopicsCallback} callback Function to call once operation is completed.
  */
 KafkaClient.prototype.createTopics = function (topics, callback) {
+  // Calls with [string, string, ...] are forwarded to support previous versions
+  if (topics.every(t => typeof t === 'string')) {
+    return Client.prototype.createTopics.apply(this, arguments);
+  }
+
   this.getController((error, broker) => {
     if (error) {
       return callback(error);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -262,6 +262,8 @@ KafkaClient.prototype.getController = function (callback) {
       return callback(new errors.BrokerNotAvailableError('Controller broker not available'));
     }
 
+    this.updateMetadatas(result);
+
     var controllerId = result[1].clusterMetadata.controllerId;
     var controllerMetadata = result[0][controllerId];
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -15,6 +15,7 @@ const BrokerWrapper = require('./wrapper/BrokerWrapper');
 const errors = require('./errors');
 const validateConfig = require('./utils').validateConfig;
 const TimeoutError = require('./errors/TimeoutError');
+const NotControllerError = require('./errors/NotControllerError');
 const protocol = require('./protocol');
 const protocolVersions = require('./protocol/protocolVersions');
 const baseProtocolVersions = protocolVersions.baseSupport;
@@ -392,6 +393,17 @@ KafkaClient.prototype.setBrokerMetadata = function (brokerMetadata) {
 KafkaClient.prototype.setClusterMetadata = function (clusterMetadata) {
   assert(clusterMetadata, 'clusterMetadata is empty');
   this.clusterMetadata = clusterMetadata;
+};
+
+KafkaClient.prototype.setControllerId = function (controllerId) {
+  if (!this.clusterMetadata) {
+    this.clusterMetadata = {
+      controllerId
+    };
+
+    return;
+  }
+  this.clusterMetadata.controllerId = controllerId;
 };
 
 KafkaClient.prototype.updateMetadatas = function (metadatas, replaceTopicMetadata) {
@@ -807,17 +819,10 @@ KafkaClient.prototype.createTopics = function (topics, callback) {
     return Client.prototype.createTopics.apply(this, arguments);
   }
 
-  this.getController((error, broker) => {
-    if (error) {
-      return callback(error);
-    }
+  const encoder = protocol.encodeCreateTopicRequest;
+  const decoder = protocol.decodeCreateTopicResponse;
 
-    const correlationId = this.nextId();
-    const request = protocol.encodeCreateTopicRequest(this.clientId, correlationId, topics, this.options.requestTimeout);
-
-    this.queueCallback(broker.socket, correlationId, [protocol.decodeCreateTopicResponse, callback]);
-    broker.write(request);
-  });
+  this.sendControllerRequest(encoder, decoder, [topics, this.options.requestTimeout], callback);
 };
 
 KafkaClient.prototype.topicExists = function (topics, callback) {
@@ -994,6 +999,51 @@ KafkaClient.prototype.verifyPayloadsHasLeaders = function (payloads, callback) {
     } else {
       callback(null);
     }
+  });
+};
+
+KafkaClient.prototype.wrapControllerCheckIfNeeded = function (encoder, decoder, encoderArgs, callback) {
+  if (callback.isControllerWrapper) {
+    return callback;
+  }
+
+  var hasBeenInvoked = false;
+
+  const wrappedCallback = (error, result) => {
+    if (error instanceof NotControllerError) {
+      this.setControllerId(null);
+
+      if (!hasBeenInvoked) {
+        hasBeenInvoked = true;
+        this.sendControllerRequest(encoder, decoder, encoderArgs, wrappedCallback);
+        return;
+      }
+    }
+
+    callback(error, result);
+  };
+
+  wrappedCallback.isControllerWrapper = true;
+
+  return wrappedCallback;
+};
+
+KafkaClient.prototype.sendControllerRequest = function (encoder, decoder, encoderArgs, callback) {
+  this.getController((error, controller) => {
+    if (error) {
+      return callback(error);
+    }
+
+    const originalArgs = _.clone(encoderArgs);
+    const originalCallback = callback;
+    const correlationId = this.nextId();
+    encoderArgs.unshift(this.clientId, correlationId);
+    const request = encoder.apply(null, encoderArgs);
+
+    callback = this.wrapControllerCheckIfNeeded(encoder, decoder, originalArgs, originalCallback);
+
+    this.queueCallback(controller.socket, correlationId, [decoder, callback]);
+    controller.write(request);
   });
 };
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -249,6 +249,12 @@ KafkaClient.prototype.getController = function (callback) {
 
     var controllerId = result[1].clusterMetadata.controllerId;
     var controllerMetadata = result[0][controllerId];
+
+    if (!controllerMetadata) {
+      logger.debug('No controller found, likely because version is less than 0.10');
+      return callback(new errors.BrokerNotAvailableError('Controller broker not available'));
+    }
+
     var broker = this.getBroker(controllerMetadata.host, controllerMetadata.port);
 
     if (!broker || !broker.isConnected()) {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -67,6 +67,7 @@ const KafkaClient = function (options) {
   this._socketId = 0;
   this.cbqueue = {};
   this.brokerMetadata = {};
+  this.clusterMetadata = {};
   this.ready = false;
 
   this.initialHosts = parseHostList(this.options.kafkaHost);
@@ -242,18 +243,27 @@ KafkaClient.prototype.connectToBroker = function (broker, callback) {
 };
 
 KafkaClient.prototype.getController = function (callback) {
-  this.loadMetadataForTopicsV2([], (error, result) => {
+  // Check for cached controller
+  if (this.clusterMetadata.controllerId) {
+    var controller = this.brokerMetadata[this.clusterMetadata.controllerId];
+    var broker = this.getBroker(controller.host, controller.port);
+
+    return callback(null, broker);
+  }
+
+  // If cached controller is not available, refresh metadata
+  this.loadMetadata((error, result) => {
     if (error) {
       return callback(error);
     }
 
-    var controllerId = result[1].clusterMetadata.controllerId;
-    var controllerMetadata = result[0][controllerId];
-
-    if (!controllerMetadata) {
-      logger.debug('No controller found, likely because version is less than 0.10');
+    // No controller will be available if api version request timed out, or if kafka version is less than 0.10.
+    if (!result[1].clusterMetadata || !result[1].clusterMetadata.controllerId) {
       return callback(new errors.BrokerNotAvailableError('Controller broker not available'));
     }
+
+    var controllerId = result[1].clusterMetadata.controllerId;
+    var controllerMetadata = result[0][controllerId];
 
     var broker = this.getBroker(controllerMetadata.host, controllerMetadata.port);
 
@@ -377,6 +387,11 @@ KafkaClient.prototype.setBrokerMetadata = function (brokerMetadata) {
   }
 };
 
+KafkaClient.prototype.setClusterMetadata = function (clusterMetadata) {
+  assert(clusterMetadata, 'clusterMetadata is empty');
+  this.clusterMetadata = clusterMetadata;
+};
+
 KafkaClient.prototype.updateMetadatas = function (metadatas, replaceTopicMetadata) {
   assert(metadatas && Array.isArray(metadatas) && metadatas.length === 2, 'metadata format is incorrect');
   logger.debug('updating metadatas');
@@ -385,6 +400,10 @@ KafkaClient.prototype.updateMetadatas = function (metadatas, replaceTopicMetadat
     this.topicMetadata = metadatas[1].metadata;
   } else {
     _.extend(this.topicMetadata, metadatas[1].metadata);
+  }
+
+  if (metadatas[1].clusterMetadata) {
+    this.setClusterMetadata(metadatas[1].clusterMetadata);
   }
 };
 
@@ -724,25 +743,77 @@ KafkaClient.prototype.clearCallbackQueue = function (socket, error) {
   delete this.cbqueue[socketId];
 };
 
-// Sends a version 1 metadata request which includes controller node in response
-KafkaClient.prototype.loadMetadataForTopicsV2 = function (topics, cb) {
-  var correlationId = this.nextId();
-  var request = protocol.encodeMetadataV1Request(this.clientId, correlationId, topics);
-  var broker = this.brokerForLeader();
-
-  this.queueCallback(broker.socket, correlationId, [protocol.decodeMetadataV1Response, cb]);
-  broker.write(request);
+/**
+ * Fetches metadata for brokers and cluster.
+ * This includes an array containing each node (id, host and port).
+ * Depending on kafka version, additional cluster information is available (controller id).
+ * @param {loadMetadataCallback} cb Function to call once metadata is loaded.
+ */
+KafkaClient.prototype.loadMetadata = function (callback) {
+  this.loadMetadataForTopics(null, callback);
 };
 
-KafkaClient.prototype.createTopicsV2 = function (topics, cb) {
-  var correlationId = this.nextId();
-  var request = protocol.encodeCreateTopicRequest(this.clientId, correlationId, topics, this.options.requestTimeout);
-  this.getController((error, broker) => {
-    if (error) {
-      return cb(error);
+/**
+ * Fetches metadata for brokers and cluster.
+ * This includes an array containing each node (id, host and port). As well as an object
+ * containing the topic name, partition, leader number, replica count, and in sync replicas per partition.
+ * Depending on kafka version, additional cluster information is available (controller id).
+ * @param {Array} topics List of topics to fetch metadata for. An empty array ([]) will fetch all topics.
+ * @param {loadMetadataCallback} callback Function to call once metadata is loaded.
+ */
+KafkaClient.prototype.loadMetadataForTopics = function (topics, callback) {
+  var broker = this.brokerForLeader();
+
+  if (!broker || !broker.socket || broker.socket.error || broker.socket.destroyed) {
+    return callback(new errors.BrokerNotAvailableError('Broker not available'));
+  }
+
+  const ensureBrokerReady = (broker, cb) => {
+    if (!broker.isReady()) {
+      logger.debug('missing apiSupport waiting until broker is ready...');
+      this.waitUntilReady(broker, cb);
+    } else {
+      cb(null);
+    }
+  };
+
+  async.series([
+    cb => {
+      ensureBrokerReady(broker, cb);
+    },
+    cb => {
+      var correlationId = this.nextId();
+      var supportedCoders = getSupportedForRequestType(broker, 'metadata');
+      var request = supportedCoders.encoder(this.clientId, correlationId, topics);
+
+      this.queueCallback(broker.socket, correlationId, [supportedCoders.decoder, cb]);
+      broker.write(request);
+    }
+  ], (err, result) => {
+    if (!err) {
+      this.updateMetadatas(result[1]);
     }
 
-    this.queueCallback(broker.socket, correlationId, [protocol.decodeCreateTopicResponse, cb]);
+    callback(err, result[1]);
+  });
+};
+
+/**
+ * Creates one or more topics.
+ * Requires kafka 0.10 or greater.
+ * @param {Array} topics Array of topics with partition and replication factor to create.
+ * @param {createTopicsCallback} callback Function to call once operation is completed.
+ */
+KafkaClient.prototype.createTopics = function (topics, callback) {
+  this.getController((error, broker) => {
+    if (error) {
+      return callback(error);
+    }
+
+    const correlationId = this.nextId();
+    const request = protocol.encodeCreateTopicRequest(this.clientId, correlationId, topics, this.options.requestTimeout);
+
+    this.queueCallback(broker.socket, correlationId, [protocol.decodeCreateTopicResponse, callback]);
     broker.write(request);
   });
 };

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -270,7 +270,7 @@ function _encodeMetadataRequest (clientId, correlationId, topics, version) {
   // In version 0 an empty array will fetch all topics.
   // In version 1+ a null value (-1) will fetch all topics. An empty array returns no topics.
   // This adds support for maintaining version 0 behaviour in client regardless of kafka version ([] = fetch all topics).
-  if (version > 0 && (Array.isArray(topics) && topics.length === 0)) {
+  if (version > 0 && ((Array.isArray(topics) && topics.length === 0) || topics === null)) {
     request.Int32BE(-1);
     return encodeRequestWithLength(request.make());
   }

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -249,7 +249,23 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
 }
 
 function encodeMetadataRequest (clientId, correlationId, topics) {
-  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.metadata);
+  return _encodeMetadataRequest(clientId, correlationId, topics);
+}
+
+function decodeMetadataResponse (resp) {
+  return _decodeMetadataResponse(resp, 0);
+}
+
+function encodeMetadataV1Request (clientId, correlationId, topics) {
+  return _encodeMetadataRequest(clientId, correlationId, topics, 1);
+}
+
+function decodeMetadataV1Response (resp) {
+  return _decodeMetadataResponse(resp, 1);
+}
+
+function _encodeMetadataRequest (clientId, correlationId, topics, version) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.metadata, version);
   request.Int32BE(topics.length);
   topics.forEach(function (topic) {
     request.Int16BE(topic.length).string(topic);
@@ -257,16 +273,25 @@ function encodeMetadataRequest (clientId, correlationId, topics) {
   return encodeRequestWithLength(request.make());
 }
 
-function decodeMetadataResponse (resp) {
+function _decodeMetadataResponse (resp, version) {
   var brokers = {};
   var out = {};
   var topics = {};
+  var controllerId = -1;
   var errors = [];
   Binary.parse(resp)
     .word32bs('size')
     .word32bs('correlationId')
     .word32bs('brokerNum')
     .loop(decodeBrokers)
+    .tap(function (vars) {
+      if (version < 1) {
+        return;
+      }
+
+      this.word32bs('controllerId');
+      controllerId = vars.controllerId;
+    })
     .word32bs('topicNum')
     .loop(_decodeTopics);
 
@@ -279,6 +304,19 @@ function decodeMetadataResponse (resp) {
         vars.host = vars.host.toString();
       })
       .word32bs('port')
+      .tap(function (vars) {
+        if (version < 1) {
+          return;
+        }
+
+        this.word16bs('rack');
+        if (vars.rack === -1) {
+          vars.rack = '';
+        } else {
+          this.buffer('rack', vars.rack);
+          vars.rack = vars.rack.toString();
+        }
+      })
       .tap(function (vars) {
         brokers[vars.nodeId] = { nodeId: vars.nodeId, host: vars.host, port: vars.port };
       });
@@ -293,6 +331,13 @@ function decodeMetadataResponse (resp) {
         vars.topic = vars.topic.toString();
       })
       .word32bs('partitionNum')
+      .tap(function (vars) {
+        if (version < 1) {
+          return;
+        }
+
+        this.word8bs('isInternal');
+      })
       .tap(function (vars) {
         if (vars.topicError !== 0) {
           return errors.push(ERROR_CODE[vars.topicError]);
@@ -332,7 +377,101 @@ function decodeMetadataResponse (resp) {
 
   if (!_.isEmpty(errors)) out.error = errors;
   out.metadata = topics;
+
+  if (version > 0) {
+    out.clusterMetadata = {
+      controllerId
+    };
+  }
+
   return [brokers, out];
+}
+
+function encodeCreateTopicRequest (clientId, correlationId, topics, timeoutMs) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.createTopics, 1);
+  request.Int32BE(topics.length);
+  topics.forEach(function (topic) {
+    request.Int16BE(topic.topic.length).string(topic.topic);
+    request.Int32BE(topic.partitions);
+    request.Int16BE(topic.replicationFactor);
+    request.Int32BE(0);
+    request.Int32BE(0);
+  });
+  request.Int32BE(timeoutMs);
+  request.Int8(0);
+
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeCreateTopicResponse (resp) {
+  var errors = [];
+
+  Binary.parse(resp)
+    .word32bs('size')
+    .word32bs('correlationId')
+    .word32bs('topicNum')
+    .loop(decodeTopics);
+
+  function decodeTopics (end, vars) {
+    if (vars.topicNum-- === 0) return end();
+
+    this.word16bs('topic')
+      .tap(function (vars) {
+        this.buffer('topic', vars.topic);
+        vars.topic = vars.topic.toString();
+      })
+      .word16bs('errorCode')
+      .word16bs('errorMessage')
+      .tap(function (vars) {
+        if (vars.errorCode === 0) {
+          return;
+        }
+
+        const TIMEOUT_ERROR_CODE = 7;
+        if (vars.errorCode === TIMEOUT_ERROR_CODE) {
+          vars.errorMessage = 'Received timeout error from broker. The topic may still have been created.';
+        } else {
+          this.buffer('errorMessage', vars.errorMessage);
+          vars.errorMessage = vars.errorMessage.toString();
+        }
+
+        errors.push({
+          topic: vars.topic,
+          error: vars.errorMessage
+        });
+      });
+  }
+
+  return errors;
+}
+
+function encodeDeleteTopicsRequest (clientId, correlationId, topics) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.deleteTopics);
+  request.Int32BE(topics.length);
+  topics.forEach(function (topic) {
+    request.Int16BE(topic.length).string(topic);
+  });
+  request.Int32BE(200);
+
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeDeleteTopicsResponse (resp) {
+  var res = {};
+  Binary.parse(resp)
+    .word32bs('size')
+    .word32bs('correlationId')
+    .word32bs('topicNum')
+    .word16bs('topic')
+    .tap(function (vars) {
+      this.buffer('topic', vars.topic);
+      vars.topic = vars.topic.toString();
+    })
+    .word16bs('errorCode')
+    .tap((vars) => {
+      console.log(vars);
+    });
+  return res;
 }
 
 function bufferToArray (num, buffer) {
@@ -1293,9 +1432,15 @@ exports.encodeOffsetFetchRequest = encodeOffsetFetchRequest;
 exports.encodeOffsetFetchV1Request = encodeOffsetFetchV1Request;
 exports.decodeOffsetFetchResponse = decodeOffsetFetchResponse;
 exports.decodeOffsetFetchV1Response = decodeOffsetFetchV1Response;
-
 exports.encodeMetadataRequest = encodeMetadataRequest;
 exports.decodeMetadataResponse = decodeMetadataResponse;
+exports.encodeMetadataV1Request = encodeMetadataV1Request;
+exports.decodeMetadataV1Response = decodeMetadataV1Response;
+
+exports.encodeCreateTopicRequest = encodeCreateTopicRequest;
+exports.decodeCreateTopicResponse = decodeCreateTopicResponse;
+exports.encodeDeleteTopicsRequest = encodeDeleteTopicsRequest;
+exports.decodeDeleteTopicsResponse = decodeDeleteTopicsResponse;
 
 exports.encodeProduceRequest = encodeProduceRequest;
 exports.encodeProduceV1Request = encodeProduceV1Request;

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -249,7 +249,7 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
 }
 
 function encodeMetadataRequest (clientId, correlationId, topics) {
-  return _encodeMetadataRequest(clientId, correlationId, topics);
+  return _encodeMetadataRequest(clientId, correlationId, topics, 0);
 }
 
 function decodeMetadataResponse (resp) {
@@ -266,6 +266,21 @@ function decodeMetadataV1Response (resp) {
 
 function _encodeMetadataRequest (clientId, correlationId, topics, version) {
   var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.metadata, version);
+
+  // In version 0 an empty array will fetch all topics.
+  // In version 1+ a null value (-1) will fetch all topics. An empty array returns no topics.
+  // This adds support for maintaining version 0 behaviour in client regardless of kafka version ([] = fetch all topics).
+  if (version > 0 && (Array.isArray(topics) && topics.length === 0)) {
+    request.Int32BE(-1);
+    return encodeRequestWithLength(request.make());
+  }
+
+  // Handle case where null is provided but version requested was 0 (not supported).
+  // Can happen if the api versions requests fails and fallback api support is used.
+  if (version === 0 && topics === null) {
+    topics = [];
+  }
+
   request.Int32BE(topics.length);
   topics.forEach(function (topic) {
     request.Int16BE(topic.length).string(topic);
@@ -403,7 +418,8 @@ function encodeCreateTopicRequest (clientId, correlationId, topics, timeoutMs) {
 }
 
 function decodeCreateTopicResponse (resp) {
-  var errors = [];
+  var topicErrorResponses = [];
+  var error;
 
   Binary.parse(resp)
     .word32bs('size')
@@ -426,51 +442,24 @@ function decodeCreateTopicResponse (resp) {
           return;
         }
 
-        const TIMEOUT_ERROR_CODE = 7;
-        if (vars.errorCode === TIMEOUT_ERROR_CODE) {
-          vars.errorMessage = 'Received timeout error from broker. The topic may still have been created.';
-        } else {
-          this.buffer('errorMessage', vars.errorMessage);
-          vars.errorMessage = vars.errorMessage.toString();
+        // Errors that are not related to the actual topic(s) but the entire request
+        // (like timeout and sending the request to a non-controller)
+        if (vars.errorCode === 7 || vars.errorCode === 41) {
+          error = createGroupError(vars.errorCode);
+          return;
         }
 
-        errors.push({
+        this.buffer('errorMessage', vars.errorMessage);
+        vars.errorMessage = vars.errorMessage.toString();
+
+        topicErrorResponses.push({
           topic: vars.topic,
           error: vars.errorMessage
         });
       });
   }
 
-  return errors;
-}
-
-function encodeDeleteTopicsRequest (clientId, correlationId, topics) {
-  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.deleteTopics);
-  request.Int32BE(topics.length);
-  topics.forEach(function (topic) {
-    request.Int16BE(topic.length).string(topic);
-  });
-  request.Int32BE(200);
-
-  return encodeRequestWithLength(request.make());
-}
-
-function decodeDeleteTopicsResponse (resp) {
-  var res = {};
-  Binary.parse(resp)
-    .word32bs('size')
-    .word32bs('correlationId')
-    .word32bs('topicNum')
-    .word16bs('topic')
-    .tap(function (vars) {
-      this.buffer('topic', vars.topic);
-      vars.topic = vars.topic.toString();
-    })
-    .word16bs('errorCode')
-    .tap((vars) => {
-      console.log(vars);
-    });
-  return res;
+  return error || topicErrorResponses;
 }
 
 function bufferToArray (num, buffer) {
@@ -1438,8 +1427,6 @@ exports.decodeMetadataV1Response = decodeMetadataV1Response;
 
 exports.encodeCreateTopicRequest = encodeCreateTopicRequest;
 exports.decodeCreateTopicResponse = decodeCreateTopicResponse;
-exports.encodeDeleteTopicsRequest = encodeDeleteTopicsRequest;
-exports.decodeDeleteTopicsResponse = decodeDeleteTopicsResponse;
 
 exports.encodeProduceRequest = encodeProduceRequest;
 exports.encodeProduceV1Request = encodeProduceV1Request;

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -329,15 +329,14 @@ function _decodeMetadataResponse (resp, version) {
       .tap(function (vars) {
         this.buffer('topic', vars.topic);
         vars.topic = vars.topic.toString();
-      })
-      .word32bs('partitionNum')
-      .tap(function (vars) {
+
         if (version < 1) {
           return;
         }
 
         this.word8bs('isInternal');
       })
+      .word32bs('partitionNum')
       .tap(function (vars) {
         if (vars.topicError !== 0) {
           return errors.push(ERROR_CODE[vars.topicError]);

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -48,11 +48,6 @@ const API_MAP = {
 
 // Since versions API isn't around until 0.10 we need to hardcode the supported API versions for 0.9 here
 const API_SUPPORTED_IN_KAFKA_0_9 = {
-  metadata: {
-    min: 0,
-    max: 1,
-    usable: 1
-  },
   fetch: {
     min: 0,
     max: 1,

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -15,7 +15,10 @@ const API_MAP = {
     [p.encodeFetchRequestV2, p.decodeFetchResponseV1]
   ],
   offset: [[p.encodeOffsetRequest, p.decodeOffsetResponse]],
-  metadata: [[p.encodeMetadataRequest, p.decodeMetadataResponse]],
+  metadata: [
+    [p.encodeMetadataRequest, p.decodeMetadataResponse],
+    [p.encodeMetadataV1Request, p.decodeMetadataV1Response]
+  ],
   leader: null,
   stopReplica: null,
   updateMetadata: null,
@@ -45,6 +48,11 @@ const API_MAP = {
 
 // Since versions API isn't around until 0.10 we need to hardcode the supported API versions for 0.9 here
 const API_SUPPORTED_IN_KAFKA_0_9 = {
+  metadata: {
+    min: 0,
+    max: 1,
+    usable: 1
+  },
   fetch: {
     min: 0,
     max: 1,

--- a/lib/protocol/protocol_struct.js
+++ b/lib/protocol/protocol_struct.js
@@ -52,7 +52,8 @@ var ERROR_CODE = {
   '28': 'InvalidCommitOffsetSize',
   '29': 'TopicAuthorizationFailed',
   '30': 'GroupAuthorizationFailed',
-  '31': 'ClusterAuthorizationFailed'
+  '31': 'ClusterAuthorizationFailed',
+  '41': 'NotController'
 };
 
 var GROUP_ERROR = {

--- a/lib/protocol/protocol_struct.js
+++ b/lib/protocol/protocol_struct.js
@@ -62,7 +62,8 @@ var GROUP_ERROR = {
   NotCoordinatorForGroup: require('../errors/NotCoordinatorForGroupError'),
   GroupLoadInProgress: require('../errors/GroupLoadInProgressError'),
   UnknownMemberId: require('../errors/UnknownMemberIdError'),
-  RebalanceInProgress: require('../errors/RebalanceInProgressError')
+  RebalanceInProgress: require('../errors/RebalanceInProgressError'),
+  NotController: require('../errors/NotControllerError')
 };
 
 var REQUEST_TYPE = {

--- a/test/mocks/mockSocket.js
+++ b/test/mocks/mockSocket.js
@@ -15,6 +15,7 @@ function FakeSocket () {
   this.close = function () {};
   this.setKeepAlive = function () {};
   this.destroy = function () {};
+  this.write = function () {};
 }
 
 util.inherits(FakeSocket, EventEmitter);

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -898,7 +898,7 @@ describe('Kafka Client', function () {
         should.not.exist(error);
         result.should.have.length(1);
         result[0].topic.should.be.exactly(topic);
-        result[0].error.should.be.exactly('Replication factor: 2 larger than available brokers: 1.');
+        result[0].error.toLowerCase().should.startWith('replication factor: 2 larger than available brokers: 1');
         done();
       });
     });

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -5,6 +5,7 @@ const Client = kafka.KafkaClient;
 const sinon = require('sinon');
 const TimeoutError = require('../lib/errors/TimeoutError');
 const TopicsNotExistError = require('../lib/errors/TopicsNotExistError');
+const NotControllerError = require('../lib/errors/NotControllerError');
 const BrokerWrapper = require('../lib/wrapper/BrokerWrapper');
 const FakeSocket = require('./mocks/mockSocket');
 const should = require('should');
@@ -845,7 +846,7 @@ describe('Kafka Client', function () {
 
     beforeEach(function (done) {
       if (process.env.KAFKA_VERSION === '0.9') {
-        this.skip();
+        return this.skip();
       }
 
       client = new Client({
@@ -917,6 +918,184 @@ describe('Kafka Client', function () {
         result[0].error.toLowerCase().should.startWith('replication factor: 2 larger than available brokers: 1');
         done();
       });
+    });
+  });
+
+  describe('#wrapControllerCheckIfNeeded', function () {
+    let client, sandbox;
+
+    beforeEach(function (done) {
+      if (process.env.KAFKA_VERSION === '0.9') {
+        return this.skip();
+      }
+
+      sandbox = sinon.sandbox.create();
+      client = new Client({
+        kafkaHost: 'localhost:9092'
+      });
+      client.once('ready', done);
+    });
+
+    afterEach(function (done) {
+      sandbox.restore();
+      client.close(done);
+    });
+
+    it('should not wrap again if already wrapped', function () {
+      const fn = _.noop;
+
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fn);
+      const secondWrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], wrapped);
+
+      wrapped.should.be.exactly(secondWrapped);
+    });
+
+    it('should wrap if not already wrapped', function () {
+      const fn = _.noop;
+
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fn);
+
+      wrapped.should.not.be.exactly(fn);
+    });
+
+    it('should set controller id to null if NotControllerError was returned once', function () {
+      const fn = _.noop;
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fn);
+      const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
+      sandbox.stub(client, 'sendControllerRequest');
+
+      wrapped(new NotControllerError('not controller'));
+
+      sinon.assert.calledOnce(setControllerIdSpy);
+      sinon.assert.alwaysCalledWithExactly(setControllerIdSpy, null);
+    });
+
+    it('should send controller request again if NotControllerError was returned once', function () {
+      var encoder = () => undefined;
+      var decoder = () => undefined;
+      var args = [];
+      const fn = _.noop;
+      const wrapped = client.wrapControllerCheckIfNeeded(encoder, decoder, args, fn);
+      const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
+      const sendControllerRequestSpy = sandbox.stub(client, 'sendControllerRequest');
+
+      wrapped(new NotControllerError('not controller'));
+
+      sinon.assert.calledOnce(setControllerIdSpy);
+      sinon.assert.alwaysCalledWithExactly(setControllerIdSpy, null);
+      sinon.assert.calledOnce(sendControllerRequestSpy);
+      sinon.assert.alwaysCalledWithExactly(sendControllerRequestSpy, encoder, decoder, args, wrapped);
+    });
+
+    it('should set controller id to null and call original callback if NotControllerError was returned on second try', function () {
+      const fnSpy = sandbox.spy();
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
+      sandbox.stub(client, 'sendControllerRequest');
+
+      wrapped(new NotControllerError('not controller'));
+      wrapped(new NotControllerError('not controller'));
+
+      sinon.assert.calledTwice(setControllerIdSpy);
+      sinon.assert.alwaysCalledWithExactly(setControllerIdSpy, null);
+      sinon.assert.calledOnce(fnSpy);
+    });
+
+    it('should call original callback if another error was returned', function () {
+      const fnSpy = sandbox.spy();
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
+
+      wrapped(new TimeoutError('operation timed out'));
+
+      sinon.assert.notCalled(setControllerIdSpy);
+      sinon.assert.calledOnce(fnSpy);
+    });
+
+    it('should call original callback if no error was returned', function () {
+      const fnSpy = sandbox.spy();
+      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
+      const expectedResult = [];
+
+      wrapped(null, expectedResult);
+
+      sinon.assert.notCalled(setControllerIdSpy);
+      sinon.assert.calledOnce(fnSpy);
+      sinon.assert.alwaysCalledWith(fnSpy, null, expectedResult);
+    });
+  });
+
+  describe('#sendControllerRequest', function () {
+    let client, sandbox;
+
+    beforeEach(function (done) {
+      if (process.env.KAFKA_VERSION === '0.9') {
+        return this.skip();
+      }
+
+      sandbox = sinon.sandbox.create();
+      client = new Client({
+        kafkaHost: 'localhost:9092'
+      });
+      client.once('ready', done);
+    });
+
+    afterEach(function (done) {
+      sandbox.restore();
+      client.close(done);
+    });
+
+    it('should wrap callback', function () {
+      const fakeBroker = new BrokerWrapper(new FakeSocket());
+      sandbox.stub(client, 'getController').yields(null, fakeBroker);
+      sandbox.stub(client, 'queueCallback');
+      const wrapControllerSpy = sandbox.spy(client, 'wrapControllerCheckIfNeeded');
+      const callbackSpy = sandbox.spy();
+
+      client.sendControllerRequest(_.noop, _.noop, [], callbackSpy);
+
+      sinon.assert.calledOnce(wrapControllerSpy);
+    });
+
+    it('should be called twice when NotController error was returned', function () {
+      const fakeBroker = new BrokerWrapper(new FakeSocket());
+      sandbox.stub(client, 'getController').yields(null, fakeBroker);
+      sandbox.stub(client, 'queueCallback').callsFake((socket, correlationId, args) => {
+        args[1](new NotControllerError('not controller'));
+      });
+      const callbackSpy = sandbox.spy();
+      const sendControllerRequestSpy = sandbox.spy(client, 'sendControllerRequest');
+
+      client.sendControllerRequest(_.noop, _.noop, [], callbackSpy);
+
+      sinon.assert.calledTwice(sendControllerRequestSpy);
+    });
+
+    it('should call encoder and queue callback', function () {
+      const fakeBroker = new BrokerWrapper(new FakeSocket());
+      sandbox.stub(client, 'getController').yields(null, fakeBroker);
+      const queueCallbackSpy = sandbox.stub(client, 'queueCallback');
+      const encoder = sandbox.spy();
+      const decoder = _.noop;
+      const args = [];
+      const callback = _.noop;
+
+      client.sendControllerRequest(encoder, decoder, args, callback);
+
+      sinon.assert.calledOnce(encoder);
+      sinon.assert.calledOnce(queueCallbackSpy);
+    });
+
+    it('should return error if controller request fails', function () {
+      const error = new TimeoutError('operation timed out');
+      sandbox.stub(client, 'getController').yields(error);
+      const callbackSpy = sandbox.spy();
+
+      client.sendControllerRequest(null, null, null, callbackSpy);
+
+      sinon.assert.calledOnce(callbackSpy);
+      sinon.assert.alwaysCalledWithExactly(callbackSpy, error);
     });
   });
 });

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -844,6 +844,10 @@ describe('Kafka Client', function () {
     let sandbox, client;
 
     beforeEach(function (done) {
+      if (process.env.KAFKA_VERSION === '0.9') {
+        this.skip();
+      }
+
       sandbox = sinon.sandbox.create();
       client = new Client({
         kafkaHost: 'localhost:9092'

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -841,14 +841,13 @@ describe('Kafka Client', function () {
   });
 
   describe('#createTopics', function () {
-    let sandbox, client;
+    let client;
 
     beforeEach(function (done) {
       if (process.env.KAFKA_VERSION === '0.9') {
         this.skip();
       }
 
-      sandbox = sinon.sandbox.create();
       client = new Client({
         kafkaHost: 'localhost:9092'
       });
@@ -856,7 +855,6 @@ describe('Kafka Client', function () {
     });
 
     afterEach(function (done) {
-      sandbox.restore();
       client.close(done);
     });
 

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -880,7 +880,21 @@ describe('Kafka Client', function () {
       ], (error, result) => {
         should.not.exist(error);
         result.should.be.empty;
-        done();
+
+        // Verify topics were properly created with partitions + replication factor by fetching metadata again
+        const verifyPartitions = (topicMetadata, expectedPartitionCount, expectedReplicatonfactor) => {
+          for (let i = 0; i < expectedPartitionCount; i++) {
+            topicMetadata[i].partition.should.be.exactly(i);
+            topicMetadata[i].replicas.length.should.be.exactly(expectedReplicatonfactor);
+          }
+        };
+
+        client.loadMetadataForTopics([topic1, topic2], (error, result) => {
+          should.not.exist(error);
+          verifyPartitions(result[1].metadata[topic1], topic1Partitions, topic1ReplicationFactor);
+          verifyPartitions(result[1].metadata[topic2], topic2Partitions, topic2ReplicationFactor);
+          done();
+        });
       });
     });
 

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -840,7 +840,7 @@ describe('Kafka Client', function () {
     });
   });
 
-  describe('#createTopicsV2', function () {
+  describe('#createTopics', function () {
     let sandbox, client;
 
     beforeEach(function (done) {
@@ -868,7 +868,7 @@ describe('Kafka Client', function () {
       const topic2ReplicationFactor = 1;
       const topic2Partitions = 1;
 
-      client.createTopicsV2([
+      client.createTopics([
         {
           topic: topic1,
           partitions: topic1Partitions,
@@ -892,7 +892,7 @@ describe('Kafka Client', function () {
       const topicReplicationFactor = 2;
       const topicPartitions = 5;
 
-      client.createTopicsV2([
+      client.createTopics([
         {
           topic: topic,
           partitions: topicPartitions,


### PR DESCRIPTION
This is a first attempt at adding support for the create topics request. I have been wanting this for a while since I work on some "management" tools for Kafka. Most other Kafka clients in other languages also seem to rely on the "metadata" solution.

This supports specifying number of partitions and replication factor. Explicit replica assignments and config entries are left out for now.

A create topic request must be sent to the controller. To find the current controller, this also adds a version 1 metadata request, which includes the controller Id in the response.

There are a couple of things that are less-than-optimal and could use some input for improvement:

- Added a "V2" suffix to resolve the conflict with current versions of `createTopics(..)` and `loadMetadataForTopics(..)`.
- KafkaClient includes these new functions, but the Admin constructor may be more appropriate for create topics, if this is intended to host more admin functionality in the future (would also resolve the `createTopics(..)` conflict on the client)?
- The metadata structure returned from `loadMetadataForTopics(..)` could use a different structure. The first item in the array is an object with all the broker nodes. Second item is an object with a metadata property containing the topics. I've added the `clusterMetadata` property here, to avoid breaking the existing structure. 
- As a follow up to this, I've left the general handling of meta data load/refresh, but the new one could replace the existing one as I see it, so controller id is always available.

Let me know of anything we need to change before this can hopefully get merged in.

Once this is wrapped up, I have delete topics request ready next, and will then add support for config entries on creation of topics.

