### PR TITLE
Fix error event in recoverFromBrokerChange

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -512,6 +512,9 @@ Client.prototype.refreshMetadata = function (topicNames, cb) {
       logger.debug('refresh metadata currentAttempt', currentAttempt);
       self.loadMetadataForTopics(topics, function (err, resp) {
         err = err || resp[1].error;
+        if (Array.isArray(err)) {
+          err = new Error(String(err));
+        }
         if (operation.retry(err)) {
           return;
         }

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -130,7 +130,7 @@ function ConsumerGroup (memberOptions, topics) {
     logger.debug('brokersChanged refreshing metadata');
     self.client.refreshMetadata(self.topics, function (error) {
       if (error) {
-        self.emit(error);
+        self.emit('error', error);
         return;
       }
       self.reconnectIfNeeded();


### PR DESCRIPTION
# Issue
In ConsumerGroup refresh metadata errors weren't being correctly emitted as 'error'.

# Changes
- Creates an error when metadata refresh request returns an error.
- Fixes emit to send error event to 'error'.