### PR TITLE
Schedules reconnect if fetch isn't started on connection.

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -532,11 +532,11 @@ ConsumerGroup.prototype.connect = function () {
 
       logger.debug('generationId', self.generationId);
 
-      logger.debug('startFetch is', startFetch);
       if (startFetch) {
         self.clearPendingFetches();
         self.fetch();
       }
+      self.scheduleReconnect(self.options.sessionTimeout);
       self.startHeartbeats();
       self.emit('connect');
       self.emit('rebalanced');


### PR DESCRIPTION
I found an edge case that if the consumer connects and the leader for the partition isn't available, the consumer never starts fetching.

You can replicate this problem with a 2 node cluster, and a topic with replication 1. Kill the broker with the partition for the topic, then start the consumer. This will cause the consumer to never start fetching messages. 