### PR TITLE
HighLevelConsumer throw FailedToRebalanceConsumerError: NODE_EXISTS when rebalancing

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -440,7 +440,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     function (callback) {
       if (newTopicPayloads.length) {
         logger.debug('HighLevelConsumer %s gaining ownership of partitions during rebalance', self.id);
-        var updatedTopicPayloads = []
+        var updatedTopicPayloads = [];
         async.eachSeries(newTopicPayloads, function (tp, cbb) {
           if (tp.partition !== undefined) {
             async.series([

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -440,6 +440,7 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     function (callback) {
       if (newTopicPayloads.length) {
         logger.debug('HighLevelConsumer %s gaining ownership of partitions during rebalance', self.id);
+        var updatedTopicPayloads = []
         async.eachSeries(newTopicPayloads, function (tp, cbb) {
           if (tp.partition !== undefined) {
             async.series([
@@ -455,7 +456,10 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
                 self.client.zk.addPartitionOwnership(self.id, self.options.groupId, tp.topic, tp.partition, function (err) {
                   if (err) {
                     addcbb(err);
-                  } else addcbb();
+                  } else {
+                    updatedTopicPayloads.push(tp);
+                    addcbb();
+                  }
                 });
               }],
               function (err) {
@@ -468,7 +472,13 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
           }
         }, function (err) {
           if (err) {
-            callback(err);
+            // Partitions already updated ZK need to release, because they may determine to new registered consumer in the coming rebalanceAttempt
+            self._releasePartitions(updatedTopicPayloads, function (releaseErr) {
+              if (releaseErr) {
+                logger.debug('HighLevelConsumer %s updatedTopicPayloads %s may stop consume with owner', self.id, JSON.stringify(updatedTopicPayloads));
+              }
+              callback(err);
+            });
           } else {
             callback();
           }


### PR DESCRIPTION
- env
  - kafka version: 0.8
  - kafka-node version: ^2.3.0
  - consumer process count: 16 (in different pc)
  - partition count: 46

- reproduce:

  - consumer1 and consumer2 is in different processes
  - consumer1 is owner of partition1+2, `consumerChanged`, rebalancing and `rebalanceAttempt`: 
    - determining to own partition3+4
    - update ZK partition3 success
    - update ZK partition4 failed
    - retry rebalanceAttempt
  - consumer2 registered when consumer1 is rebalancing, start to rebalancing and `rebalanceAttempt`: 
    - determining to own partition3
    - update ZK failed by: `FailedToRebalanceConsumerError`:`NODE_EXISTS`
    - retry continuously..cannot emit rebalanced
  - consumer1: retry `rebalanceAttempt`
    - found consumer2 and determining to own partition4
    - update ZK partition4 success
    - rebalanced

- result:

  consumer1 is owner of partition3 in ZK and never consume partition3, but only own partition4 in memory `topicPayloads`.
  consumer2 cannot complete the rebalance process and throw `FailedToRebalanceConsumerError` , beacuse the owner node in ZK exists which created by consumer1.

- solution:

  **If a tp update ZK failed when rebalanceAttempt, release the tp which already updated success. In another word, when the long rebalancing process failed, some ZK updated need to rollback.
  The PR has proved could solved the issues in our product env，and all consumers is working, all partitions is consuming~**

- about testcase:
  Sorry for missing it. The simulation reappeared is difficult. Glad to see someone would add it, thanks.

Fixes #487 #449 
