### PR TITLE
fix listGroups error handling resolves #984

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -460,9 +460,7 @@ KafkaClient.prototype.getListGroups = function (callback) {
         callback(err);
         return;
       }
-      // removing {error: null} before merging
-      results = _.values(_.map(results, result => _.omitBy(result, _.isNull)));
-      results.unshift({});
+      results = _.values(results);
       callback(null, _.merge.apply({}, results));
     }
   );

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -1204,12 +1204,14 @@ function encodeListGroups (clientId, correlationId) {
 
 function decodeListGroups (resp) {
   let groups = {};
+  let error;
+
   Binary.parse(resp)
     .word32bs('size')
     .word32bs('correlationId')
     .word16bs('errorCode')
     .tap(vars => {
-      groups.error = createGroupError(vars.errorCode);
+      error = createGroupError(vars.errorCode);
     })
     .word32bs('groupNum')
     .loop(function (end, vars) {
@@ -1227,7 +1229,7 @@ function decodeListGroups (resp) {
         });
     });
 
-  return groups;
+  return error || groups;
 }
 
 function encodeVersionsRequest (clientId, correlationId) {

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const Admin = require('../lib/admin');
+const ConsumerGroup = require('../lib/consumerGroup');
+const uuid = require('uuid');
+
+describe('Admin', function () {
+  describe('#listGroups', function () {
+    const createTopic = require('../docker/createTopic');
+    let admin, consumer;
+    const topic = uuid.v4();
+    const groupId = 'test-group-id';
+
+    before(function (done) {
+      if (process.env.KAFKA_VERSION === '0.8') {
+        this.skip();
+      }
+
+      createTopic(topic, 1, 1).then(function () {
+        consumer = new ConsumerGroup({
+          kafkaHost: 'localhost:9092',
+          groupId: groupId
+        }, topic);
+        consumer.once('connect', function () {
+          done();
+        });
+      });
+    });
+
+    after(function (done) {
+      consumer.close(done);
+    });
+
+    it('should return a list of consumer groups', function (done) {
+      admin = new Admin(consumer.client);
+      admin.listGroups(function (error, res) {
+        res.should.have.keys(groupId);
+        res[groupId].should.eql('consumer');
+        done(error);
+      });
+    });
+  });
+});

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -806,4 +806,37 @@ describe('Kafka Client', function () {
       });
     });
   });
+
+  describe('#getListGroups', function () {
+    let client;
+
+    before(function () {
+      if (process.env.KAFKA_VERSION === '0.8') {
+        this.skip();
+      }
+    });
+
+    beforeEach(function (done) {
+      client = new Client({
+        kafkaHost: 'localhost:9092'
+      });
+      client.once('ready', done);
+    });
+
+    afterEach(function (done) {
+      client.close(done);
+    });
+
+    it('should error if the client is not ready', function (done) {
+      client = new Client({
+        kafkaHost: 'localhost:9092',
+        autoConnect: false
+      });
+      client.getListGroups(function (error, res) {
+        error.should.be.an.instanceOf(Error);
+        error.message.should.be.exactly('Client is not ready (getListGroups)');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Tested locally via symlinking into another project. I don't see any unit tests for `listGroups` but I can add some if you'd like.

Also, `describeGroups` will likely need the same fix which I'd be glad to submit in a separate PR.