### PR TITLE
Fix controller check when controller id is 0

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -259,7 +259,7 @@ KafkaClient.prototype.getController = function (callback) {
     }
 
     // No controller will be available if api version request timed out, or if kafka version is less than 0.10.
-    if (!result[1].clusterMetadata || !result[1].clusterMetadata.controllerId) {
+    if (!result[1].clusterMetadata || result[1].clusterMetadata.controllerId == null) {
       return callback(new errors.BrokerNotAvailableError('Controller broker not available'));
     }
 


### PR DESCRIPTION
Small fix in addition to the previous PR. Check for null or undefined in metadata response instead for cases when broker with id "0" is controller.