### PR TITLE
Fix describe groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,20 @@ Result:
 }
 ```
 
+### createTopics(topics, cb)
+
+```js
+var topics = [{
+  topic: 'topic1',
+  partitions: 1,
+  replicationFactor: 2
+}];
+admin.createTopics(topics, (err, res) => {
+  // result is an array of any errors if a given topic could not be created
+})
+```
+
+See [createTopics](#createtopicstopics-cb)
 
 # Troubleshooting / FAQ
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -1248,6 +1248,7 @@ function encodeDescribeGroups (clientId, correlationId, groups) {
 
 function decodeDescribeGroups (resp) {
   let results = {};
+  let error;
 
   Binary.parse(resp).word32bs('size').word32bs('correlationId').word32bs('describeNum').loop(decodeDescriptions);
 
@@ -1257,7 +1258,7 @@ function decodeDescribeGroups (resp) {
     let described = { members: [] };
     this.word16bs('errorCode')
       .tap(vars => {
-        described.error = createGroupError(vars.errorCode);
+        error = createGroupError(vars.errorCode);
       })
       .word16bs('groupId')
       .tap(vars => {
@@ -1322,7 +1323,7 @@ function decodeDescribeGroups (resp) {
       });
   }
 
-  return results;
+  return error || results;
 }
 
 function encodeListGroups (clientId, correlationId) {

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -4,7 +4,7 @@ const Admin = require('../lib/admin');
 const ConsumerGroup = require('../lib/consumerGroup');
 const uuid = require('uuid');
 
-describe('Admin', function () {
+describe.only('Admin', function () {
   describe('#listGroups', function () {
     const createTopic = require('../docker/createTopic');
     let admin, consumer;
@@ -36,6 +36,54 @@ describe('Admin', function () {
       admin.listGroups(function (error, res) {
         res.should.have.keys(groupId);
         res[groupId].should.eql('consumer');
+        done(error);
+      });
+    });
+  });
+
+  describe('#describeGroups', function () {
+    const createTopic = require('../docker/createTopic');
+    let admin, consumer;
+    const topic = uuid.v4();
+    const groupId = 'test-group-id';
+
+    before(function (done) {
+      if (process.env.KAFKA_VERSION === '0.8') {
+        this.skip();
+      }
+
+      createTopic(topic, 1, 1).then(function () {
+        consumer = new ConsumerGroup({
+          kafkaHost: 'localhost:9092',
+          groupId: groupId
+        }, topic);
+        consumer.once('connect', function () {
+          done();
+        });
+      });
+    });
+
+    after(function (done) {
+      consumer.close(done);
+    });
+
+    it('should describe a list of consumer groups', function (done) {
+      admin = new Admin(consumer.client);
+      admin.describeGroups([groupId], function (error, res) {
+        res.should.have.keys(groupId);
+        res[groupId].should.have.property('members').with.lengthOf(1);
+        res[groupId].should.have.property('state', 'Stable');
+        done(error);
+      });
+    });
+
+    it('should return empty members if consumer group doesnt exist', function (done) {
+      admin = new Admin(consumer.client);
+      const nonExistentGroup = 'non-existent-group';
+      admin.describeGroups([nonExistentGroup], function (error, res) {
+        res.should.have.keys(nonExistentGroup);
+        res[nonExistentGroup].should.have.property('members').with.lengthOf(0);
+        res[nonExistentGroup].should.have.property('state', 'Dead');
         done(error);
       });
     });

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -4,7 +4,7 @@ const Admin = require('../lib/admin');
 const ConsumerGroup = require('../lib/consumerGroup');
 const uuid = require('uuid');
 
-describe.only('Admin', function () {
+describe('Admin', function () {
   describe('#listGroups', function () {
     const createTopic = require('../docker/createTopic');
     let admin, consumer;


### PR DESCRIPTION
Related to https://github.com/SOHU-Co/kafka-node/issues/984 and https://github.com/SOHU-Co/kafka-node/pull/985

I also added an entry for `createTopics` in the `admin` section of the README. Current README has the `createTopic` entry under `Producer`. Is this incorrect? I can revert if necessary.