### PR TITLE
Update client.js

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -113,13 +113,13 @@ Client.prototype.connect = function () {
       self.emit('error', error);
     }
   });
-  zk.once('disconnected', function () {
+/*  zk.once('disconnected', function () {
     if (!zk.closed) {
       zk.close();
       self.connect();
       self.emit('zkReconnect');
     }
-  });
+  });*/
   zk.on('error', function (err) {
     self.emit('error', err);
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -115,6 +115,7 @@ Client.prototype.connect = function () {
   });
   zk.once('disconnected', function () {
     if (!zk.closed) {
+      
       self.emit('zkReconnect');
     }
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -113,6 +113,11 @@ Client.prototype.connect = function () {
       self.emit('error', error);
     }
   });
+  zk.once('disconnected', function () {
+    if (!zk.closed) {      
+      self.emit('zkReconnect');
+    }
+  });
   zk.on('error', function (err) {
     self.emit('error', err);
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -113,13 +113,6 @@ Client.prototype.connect = function () {
       self.emit('error', error);
     }
   });
-/*  zk.once('disconnected', function () {
-    if (!zk.closed) {
-      zk.close();
-      self.connect();
-      self.emit('zkReconnect');
-    }
-  });*/
   zk.on('error', function (err) {
     self.emit('error', err);
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,8 +114,7 @@ Client.prototype.connect = function () {
     }
   });
   zk.once('disconnected', function () {
-    if (!zk.closed) {
-      
+    if (!zk.closed) {      
       self.emit('zkReconnect');
     }
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,7 @@ Client.prototype.connect = function () {
     }
   });
   zk.once('disconnected', function () {
-    if (!zk.closed) {      
+    if (!zk.closed) {
       self.emit('zkReconnect');
     }
   });


### PR DESCRIPTION
when "disconnected" event emited from "node-zookeeper-client/lib/ConnectionManager.js", it already begin reconect in its internal [https://github.com/alexguan/node-zookeeper-client/blob/290e4684a1e0b6d824b9e78df00781e131db5861/lib/ConnectionManager.js#L278](url)

if reconnet here(client.js), the zookeeper  TCP Connections will increase one when zookeeper server reboot. for example, first reboot zookeeper server,the num of connection from client to zookeeper is 2; second reboot zookeeper,the num of connection is 3. the kafka connections also increase one per reboot