### PR TITLE
Add support for max timeout in Consumer Group

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -44,6 +44,7 @@ const DEFAULTS = {
   retries: 10,
   retryFactor: 1.8,
   retryMinTimeout: 1000,
+  retryMaxTimeout: Infinity,
   commitOffsetsOnFirstJoin: true,
   connectOnReady: true,
   migrateHLC: false,

--- a/lib/consumerGroupRecovery.js
+++ b/lib/consumerGroupRecovery.js
@@ -112,7 +112,8 @@ ConsumerGroupRecovery.prototype.getRetryTimeout = function (error) {
     this._timeouts = retry.timeouts({
       retries: this.options.retries,
       factor: this.options.retryFactor,
-      minTimeout: this.options.retryMinTimeout
+      minTimeout: this.options.retryMinTimeout,
+      maxTimeout: this.options.retryMaxTimeout
     });
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -253,6 +253,7 @@ export interface ConsumerGroupOptions {
   retries?: number;
   retryFactor?: number;
   retryMinTimeout?: number;
+  retryMaxTimeout?: number;
   connectOnReady?: boolean;
 }
 


### PR DESCRIPTION
node retry has a maxTimeout option, adding support for kafka node to pass max timeout to node retry.