### PR TITLE
Add fetchCommitsV1 functionality and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,33 @@ var kafka = require('kafka-node'),
     });
 ```
 
+### fetchCommitsV1(groupid, payloads, cb)
+
+> ⚠️**WARNING**: commits are from the broker and is only compatible with the new `ConsumerGroup` and will **NOT** with the old `HighLevelConsumer`
+
+Fetch the last committed offset in a topic of a specific consumer group
+
+* `groupId`: consumer group
+* `payloads`: **Array**,array of `OffsetFetchRequest`, `OffsetFetchRequest` is a JSON object like:
+
+``` js
+{
+   topic: 'topicName',
+   partition: 0 //default 0
+}
+```
+
+Example
+
+```js
+var kafka = require('kafka-node'),
+    client = new kafka.Client(),
+    offset = new kafka.Offset(client);
+    offset.fetchCommitsV1('groupId', [
+        { topic: 't', partition: 0 }
+    ], function (err, data) {
+    });
+```
 ### fetchLatestOffsets(topics, cb)
 
 Example

--- a/lib/client.js
+++ b/lib/client.js
@@ -282,6 +282,14 @@ Client.prototype.sendOffsetFetchV1Request = function (group, payloads, cb) {
   this.sendGroupRequest(encoder, decoder, arguments);
 };
 
+Client.prototype.setCoordinatorIdAndSendOffsetFetchV1Request = function (group, payloads, cb) {
+  this.sendGroupCoordinatorRequest(group, (err, coordinatorInfo) => {
+    if (err) return cb(new errors.BrokerNotAvailableError('Broker not available'));
+    this.coordinatorId = String(coordinatorInfo.coordinatorId);
+    this.sendOffsetFetchV1Request(group, payloads, cb);
+  });
+};
+
 Client.prototype.sendOffsetFetchRequest = function (group, payloads, cb) {
   var encoder = protocol.encodeOffsetFetchRequest(group);
   var decoder = protocol.decodeOffsetFetchResponse;

--- a/lib/offset.js
+++ b/lib/offset.js
@@ -40,6 +40,14 @@ Offset.prototype.buildPayloads = function (payloads) {
   });
 };
 
+Offset.prototype.buildOffsetFetchV1Payloads = function (payloads) {
+  return payloads.reduce(function (out, p) {
+    out[p.topic] = out[p.topic] || [];
+    out[p.topic].push(p.partition || 0);
+    return out;
+  }, {});
+};
+
 Offset.prototype.commit = function (groupId, payloads, cb) {
   if (!this.ready) {
     this.once('ready', () => this.commit(groupId, payloads, cb));
@@ -54,6 +62,14 @@ Offset.prototype.fetchCommits = function (groupId, payloads, cb) {
     return;
   }
   this.client.sendOffsetFetchRequest(groupId, this.buildPayloads(payloads), cb);
+};
+
+Offset.prototype.fetchCommitsV1 = function (groupId, payloads, cb) {
+  if (!this.ready) {
+    this.once('ready', () => this.fetchCommitsV1(groupId, payloads, cb));
+    return;
+  }
+  this.client.setCoordinatorIdAndSendOffsetFetchV1Request(groupId, this.buildOffsetFetchV1Payloads(payloads), cb);
 };
 
 Offset.prototype.fetchLatestOffsets = function (topics, cb) {

--- a/test/test.offset.js
+++ b/test/test.offset.js
@@ -4,6 +4,7 @@ var libPath = process.env['kafka-cov'] ? '../lib-cov/' : '../lib/';
 var Producer = require(libPath + 'producer');
 var Offset = require(libPath + 'offset');
 var Client = require(libPath + 'client');
+var ConsumerGroup = require(libPath + 'consumerGroup');
 const uuid = require('uuid');
 
 var client, producer, offset;
@@ -105,6 +106,45 @@ describe('Offset', function () {
     });
   });
 
+  describe('#fetchCommitsV1', function () {
+    var topic, topics, groupId, expectedCommittedOffset;
+    topic = `_exist_topic_3_test`;
+    topics = [ { topic: topic, partition: 0 } ];
+    groupId = `_groupId_commit_v1_test`;
+    before(function (done) {
+      producer.send([{ topic, messages: ['firstMessage'] }], (err, data) => { console.log(`Producer sent data: ${JSON.stringify(data)}, err: ${JSON.stringify(err)}`); });
+      createCGandCommitToLatestOffset(groupId, topic, (err, highWaterOffset) => {
+        expectedCommittedOffset = highWaterOffset;
+        done(err);
+      });
+    });
+
+    it('should return -1 when the consumer group has no commits on the broker', function (done) {
+      var groupIdNoCommits = groupId + '2';
+      offset.fetchCommitsV1(groupIdNoCommits, topics, function (err, data) {
+        data.should.be.ok;
+        Object.keys(data)[0].should.equal(topic);
+        data[topic][0].should.equal(-1);
+        done(err);
+      });
+    });
+
+    it('should get the last committed offset consumer group on the broker', function (done) {
+      offset.fetchCommitsV1(groupId, topics, function (err, data) {
+        data.should.be.ok;
+        Object.keys(data)[0].should.equal(topic);
+        data[topic][0].should.equal(expectedCommittedOffset);
+        done(err);
+      });
+    });
+
+    it('should keep calling fetchCommits until offset is ready', function (done) {
+      var topic = '_exist_topic_3_test';
+      var topics = [ { topic: topic, offset: 10 } ];
+      offset.fetchCommitsV1('_groupId_commit_1_test', topics, done);
+    });
+  });
+
   describe('#fetchEarliestOffsets', function () {
     it('should callback with error if topic does not exist', function (done) {
       offset.fetchEarliestOffsets([uuid.v4()], function (error) {
@@ -146,3 +186,33 @@ describe('Offset', function () {
     });
   });
 });
+
+const createCGandCommitToLatestOffset = (groupId, topic, cb) => {
+  try {
+    var consumerGroupOptions = {
+      groupId: groupId,
+      fromOffset: 'earliest',
+      kafkaHost: 'localhost:9092',
+      autoCommitIntervalMs: 1,
+      autoCommit: true
+    };
+    var consumerGroup = new ConsumerGroup(consumerGroupOptions, topic);
+    consumerGroup.on('message', (message) => {
+      console.log('got message');
+      console.log(`Got a message on the consumer group: ${JSON.stringify(message)}`);
+      if (message.offset === message.highWaterOffset - 1) {
+        setTimeout(() => {
+          consumerGroup.close(true, () => {
+            console.log('closed cg');
+            return cb(null, message.highWaterOffset);
+          });
+        }, 0);
+      }
+    });
+    consumerGroup.on('error', (err) => {
+      return cb(err);
+    });
+  } catch (e) {
+    return cb(e);
+  }
+};


### PR DESCRIPTION
References #558, #954  

offset#fetchCommits gets the latest committed offsets from zookeeper. This pull request adds offset#fetchCommitsV1 functionality for fetching commits from the brokers, which aligns with how ConsumerGroup commits are stored. 

Current implementation uses the same data structure as an input that offset#fetchCommits uses and converts it to the V1 format, let me know if we should instead expect it to already be in the V1 format.
