### PR TITLE
Treat commits during not a member as an error

### DIFF
--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -633,7 +633,7 @@ ConsumerGroup.prototype.sendOffsetCommitRequest = function (commits, cb) {
   if (this.generationId && this.memberId) {
     this.client.sendOffsetCommitV2Request(this.options.groupId, this.generationId, this.memberId, commits, cb);
   } else {
-    cb(null, 'Nothing to be committed');
+    cb(new Error('Not member of group'));
   }
 };
 


### PR DESCRIPTION
We should not blindly send a success message when the commits are not actually committed