### PR TITLE
Pass longpolling argument

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -279,7 +279,7 @@ KafkaClient.prototype.getController = function (callback) {
 };
 
 KafkaClient.prototype.getBroker = function (host, port, longpolling) {
-  const brokers = this.getBrokers();
+  const brokers = this.getBrokers(longpolling);
 
   var addr = host + ':' + port;
   return brokers[addr] || this.setupBroker(host, port, longpolling, brokers);


### PR DESCRIPTION
@aikar had a relevant comment on https://github.com/SOHU-Co/kafka-node/commit/a3653ba2d75a180be1e35f25be66cae0c9dcaa1c#commitcomment-29823455, that any longpolling argument should be passed. This is for any future code that would use `getBroker` and pass a value (currently none does).