### PR TITLE
Return error when connecting to brokers if client is closing

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -92,10 +92,13 @@ util.inherits(KafkaClient, Client);
      */
 
 function parseHost (hostString) {
-  const piece = hostString.split(':');
+  const ip = hostString.substring(0, hostString.lastIndexOf(':'));
+  const port = hostString.substring(hostString.lastIndexOf(':') + 1);
+  const isIpv6 = ip.match(/\[(.*)\]/);
+  const host = isIpv6 ? isIpv6[1] : ip;
   return {
-    host: piece[0],
-    port: piece[1]
+    host,
+    port
   };
 }
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -188,6 +188,10 @@ KafkaClient.prototype.connectToBrokers = function (hosts, callback) {
     },
     () => !this.closing && !broker && index < hosts.length,
     () => {
+      if (this.closing) {
+        return callback(new Error('client is closing'));
+      }
+
       if (broker) {
         return callback(null, broker);
       }
@@ -195,7 +199,7 @@ KafkaClient.prototype.connectToBrokers = function (hosts, callback) {
       if (errors.length) {
         callback(errors.pop());
       } else {
-        callback(new Error('client is closing?'));
+        callback(new Error('failed to connect to brokers'));
       }
     }
   );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,7 +138,9 @@ export class Offset {
 }
 
 export class KeyedMessage {
-  constructor (key: string, value: string | Buffer);
+  key: string | Buffer;
+  value: string | Buffer;
+  constructor (key: string | Buffer, value: string | Buffer);
 }
 
 export class ProducerStream extends Writable {
@@ -161,7 +163,7 @@ export interface Message {
   offset?: number;
   partition?: number;
   highWaterOffset?: number;
-  key?: string;
+  key?: string | Buffer;
 }
 
 export interface ProducerOptions {
@@ -208,7 +210,7 @@ export interface ZKOptions {
 export interface ProduceRequest {
   topic: string;
   messages: any; // string[] | Array<KeyedMessage> | string | KeyedMessage
-  key?: string;
+  key?: string | Buffer;
   partition?: number;
   attributes?: number;
 }


### PR DESCRIPTION
I've filed an issue regarding this commit, please refer to https://github.com/SOHU-Co/kafka-node/issues/1045. There is a race condition when broker is disconnecting and Kafka client sometimes still attempts to refreshBrokerMetadata when client is closing.