### PR TITLE
Return error when connecting to brokers if client is closing

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -92,10 +92,13 @@ util.inherits(KafkaClient, Client);
      */
 
 function parseHost (hostString) {
-  const piece = hostString.split(':');
+  const ip = hostString.substring(0, hostString.lastIndexOf(':'));
+  const port = hostString.substring(hostString.lastIndexOf(':') + 1);
+  const isIpv6 = ip.match(/\[(.*)\]/);
+  const host = isIpv6 ? isIpv6[1] : ip;
   return {
-    host: piece[0],
-    port: piece[1]
+    host,
+    port
   };
 }
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -188,6 +188,10 @@ KafkaClient.prototype.connectToBrokers = function (hosts, callback) {
     },
     () => !this.closing && !broker && index < hosts.length,
     () => {
+      if (this.closing) {
+        return callback(new Error('client is closing'));
+      }
+
       if (broker) {
         return callback(null, broker);
       }
@@ -195,7 +199,7 @@ KafkaClient.prototype.connectToBrokers = function (hosts, callback) {
       if (errors.length) {
         callback(errors.pop());
       } else {
-        callback(new Error('client is closing?'));
+        callback(new Error('failed to connect to brokers'));
       }
     }
   );


### PR DESCRIPTION
I've filed an issue regarding this commit, please refer to https://github.com/SOHU-Co/kafka-node/issues/1045. There is a race condition when broker is disconnecting and Kafka client sometimes still attempts to refreshBrokerMetadata when client is closing.