### PR TITLE
Skip processing buffer after partial message detected

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -263,12 +263,13 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
   const messageSetSize = messageSet.length;
   while (messageSet.length > 0) {
     var cur = 8 + 4 + 4 + 1 + 1 + 4 + 4;
+    var partial = false;
     Binary.parse(messageSet)
       .word64bs('offset')
       .word32bs('messageSize')
       .tap(function (vars) {
         if (vars.messageSize > messageSet.length - 12) {
-          vars.partial = true;
+          partial = true;
         }
       })
       .word32bs('crc')
@@ -309,7 +310,7 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
           return;
         }
 
-        if (!vars.partial && vars.offset !== null) {
+        if (!partial && vars.offset !== null) {
           messageCount++;
           set.push(vars.offset);
           if (!cb) return;
@@ -336,6 +337,8 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
           });
         }
       });
+    // Skip decoding binary left in the message set if partial message detected
+    if (partial) break;
     // Defensive code around potential denial of service
     if (maxTickMessages && messageCount > maxTickMessages) break;
     messageSet = messageSet.slice(cur);


### PR DESCRIPTION
Kafka server may add partial message to the end of the message set with, for example, the following data:
```
MessageSet => [Offset MessageSize Message]
  Offset => 0
  MessageSize => 16216
Message => Crc MagicByte Attributes Key Value 
  Crc => 0
  MagicByte => 0
  Attributes => 0
  Key => buffer of 0 bits
  Value => buffer of 0 bits
```

Instead of key/value the message is filled with 0 bits sequence. I couldn't find any special requirements on the format of the partial message, so maybe this is allowed behavior. But with such message from the server consumer continues decoding 0 bits, emits empty messages and the worst - it ends up with array of 0 offsets, e.g. [96510, 96511, 96512, 0, 0, 0, 0, 0], which leads to starting reading the next batch from 0 offset and gets into an infinite cycle.

(Took info about protocol from https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Messagesets and https://kafka.apache.org/documentation.html#impl_reads )