### PR TITLE
Don't transmitMessages if already reading

### DIFF
--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -88,8 +88,10 @@ class ConsumerGroupStream extends Readable {
       logger.debug('consumerGroup is not ready, calling consumerGroup.connect');
       this.consumerGroup.connect();
     }
-    this._reading = true;
-    this.transmitMessages();
+    if (!this._reading) {
+      this._reading = true;
+      this.transmitMessages();
+    }
   }
 
   commit (message, force, callback) {


### PR DESCRIPTION
This causes fetch requests to be sent out in the middle
a read operation, causing some weird ordering to occur.