### PR TITLE
ConsumerGroupStream: Only set committing=true if it can be set false later

### DIFF
--- a/lib/consumerGroupStream.js
+++ b/lib/consumerGroupStream.js
@@ -107,9 +107,9 @@ class ConsumerGroupStream extends Readable {
   }
 
   commitQueued (commits, force, callback) {
-    this.committing = true;
-
     if (!force) {
+      this.committing = true;
+
       this.autoCommitTimer = setTimeout(() => {
         logger.debug('setting committing to false');
         this.committing = false;


### PR DESCRIPTION
Ensure that calling `commitQueued()` with `force=true` won't unbalance the `this.committing` true/false assignments.

Issue https://github.com/SOHU-Co/kafka-node/issues/1065