### PR TITLE
Partition-aware async consumer proof of concept

### DIFF
--- a/example/async.js
+++ b/example/async.js
@@ -4,12 +4,14 @@ const kafka = require('..');
 
 const options = {
   kafkaHost: 'localhost:9092',
-  groupId: 'kafka-node-demo'
+  groupId: 'kafka-node-demo',
+  maxUncommittedMessages: 5,
 };
 
 function doSomethingAsync () {
   return new Promise(resolve => {
-    setTimeout(() => resolve(), 50 + Math.random() * 200);
+    // setTimeout(() => resolve(), 50 + Math.random() * 200);
+    resolve();
   });
 }
 

--- a/example/async.js
+++ b/example/async.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const kafka = require('..');
+
+const options = {
+  kafkaHost: 'localhost:9092',
+  groupId: 'kafka-node-demo'
+};
+
+function doSomethingAsync () {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), 50 + Math.random() * 200);
+  });
+}
+
+const consumer = new kafka.AsyncConsumerGroup(options, 'kafka-node-demo');
+consumer.on('error', err => {
+  console.error('error: unexpected error from consumer', err);
+});
+
+//
+// `consumer.consume(async msg => ...)` also works, automatically invoking
+// ack() when the promise resolves.
+//
+consumer.consume(msg => {
+  console.log(JSON.stringify(msg));
+
+  //
+  // just demonstrate that we're processing messages asynchronously
+  //
+  doSomethingAsync().then(() => msg.ack());
+});
+
+console.log('waiting for messages to arrive ¯\\_(ツ)_/¯');
+
+function exitGracefully () {
+  console.log('closing consumer');
+  consumer.close()
+    .then(() => {
+      console.log('consumer closed, exiting');
+      process.exit(0);
+    });
+}
+
+process.once('SIGTERM', exitGracefully);
+process.once('SIGINT', exitGracefully);

--- a/kafka.js
+++ b/kafka.js
@@ -1,6 +1,7 @@
 exports.HighLevelConsumer = require('./lib/highLevelConsumer');
 exports.HighLevelProducer = require('./lib/highLevelProducer');
 exports.ProducerStream = require('./lib/producerStream');
+exports.AsyncConsumerGroup = require('./lib/asyncConsumerGroup');
 exports.ConsumerGroup = require('./lib/consumerGroup');
 exports.ConsumerGroupStream = require('./lib/consumerGroupStream');
 exports.Consumer = require('./lib/consumer');

--- a/lib/asyncConsumerGroup/asyncConsumerGroup.js
+++ b/lib/asyncConsumerGroup/asyncConsumerGroup.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const EventEmitter = require('events');
+const ConsumerGroup = require('../consumerGroup');
+const PartitionProcessor = require('./partitionProcessor');
+const CommitManager = require('./commitManager');
+const debug = require('debug')('kafka-node:asyncConsumerGroup:AsyncConsumerGroup');
+
+const DEFAULT_OPTIONS = {
+  maxUncommittedMessages: 1,
+  prefetchHighWatermark: 10000,
+  prefetchLowWatermark: 1000,
+  commitRetryOptions: {
+    minTimeout: 100,
+    maxTimeout: 5000,
+    factor: 2.5,
+    randomize: true
+  },
+  processRetryOptions: {
+    minTimeout: 100,
+    maxTimeout: 5000,
+    factory: 2.5,
+    retries: 5,
+    randomize: true
+  }
+};
+
+//
+// TODO global and per-partition processing stats, commit stats, etc.
+//
+class AsyncConsumerGroup extends EventEmitter {
+  constructor (options, topics) {
+    super();
+
+    if (!options) {
+      options = {};
+    }
+
+    //
+    // TODO if user-provided onRebalance is called, we should invoke it (or perhaps we could offer an alternative API)
+    //
+    const overrides = {
+      paused: true,
+      autoCommit: false,
+      onRebalance: (isMember, cb) => this._onGroupRebalanceBegin(isMember, cb)
+    };
+
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options, overrides);
+    this.closing = false;
+    this.closed = false;
+    this.buffered = 0;
+    this.idle = true;
+    this.consuming = false;
+
+    this.group = new InternalConsumerGroup(this.options, topics);
+    this.group.on('error', err => this._onInternalError(err));
+
+    this.commitManager = new CommitManager(this.group, this.options);
+    this.commitManager.on('error', err => this._onInternalError(err));
+
+    this.partitionProcessors = new Map();
+  }
+
+  consume (cb) {
+    if (this.consuming) {
+      throw new Error('consume() should only be called once');
+    }
+
+    this.consuming = true;
+
+    this.commitManager.on('internal:commit-complete', info => this._onCommitComplete(info));
+    this.commitManager.on('internal:commit-retry', err => this._onCommitRetry(err));
+    this.group.on('rebalanced', () => this._onGroupRebalanceEnd());
+    this.group.on('message', msg => this._onGroupMessage(msg, cb));
+    this.group.on('done', () => this._onGroupBatchDone());
+    this.group.resume();
+  }
+
+  close () {
+    if (this.closing) {
+      return Promise.reject(new Error('already closing/closed'));
+    }
+
+    debug('closing');
+
+    this.closing = true;
+
+    return new Promise((resolve, reject) => {
+      this.group.pause();
+
+      this._acquiesce()
+        .then(() => this._closeGroup())
+        .then(() => {
+          debug('closed');
+          resolve();
+        })
+        .catch(err => {
+          reject(err);
+        });
+    });
+  }
+
+  _closeGroup () {
+    return new Promise((resolve, reject) => {
+      this.group.close(err => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve();
+      });
+    });
+  }
+
+  _acquiesce () {
+    debug('pausing fetch requests while we acquiesce');
+    this.group.pause();
+
+    return this._acquiescePartitionProcessors()
+      .then(() => this._acquiesceCommitManager());
+  }
+
+  _acquiescePartitionProcessors () {
+    debug('waiting for partition processors to acquiesce');
+
+    const promises = [];
+    for (const partitionProcessor of this.partitionProcessors.values()) {
+      promises.push(partitionProcessor.acquiesce());
+    }
+    return Promise.all(promises)
+      .then(() => {
+        //
+        // once all partition processors have acquiesced, purge the existing map.
+        // (no way to resume & we're about to rebalance or close anyway)
+        //
+        debug('partition processors have acquiesced');
+        this.partitionProcessors = new Map();
+      });
+  }
+
+  _acquiesceCommitManager () {
+    debug('waiting for commit manager to acquiesce');
+
+    return this.commitManager.acquiesce()
+      .then(() => {
+        debug('commit manager has acquiesced, purging cached offsets');
+
+        this.commitManager.purge();
+      });
+  }
+
+  _onGroupRebalanceBegin (isMember, cb) {
+    debug('begin rebalance');
+
+    //
+    // FIXME presumably we have a limited amount of time to acquiesce.
+    //
+    const acquiesceThenCommitAndRebalance = () => {
+      this._acquiesce()
+        .then(() => cb())
+        .catch(err => cb(err));
+    };
+
+    if (this.idle) {
+      acquiesceThenCommitAndRebalance();
+    } else {
+      this.once('internal:idle', () => acquiesceThenCommitAndRebalance());
+    }
+  }
+
+  _onGroupRebalanceEnd () {
+    debug('end rebalance');
+
+    if (!this.closing && this.group.paused && this.buffered < this.options.prefetchHighWatermark) {
+      debug('resuming fetch after rebalance');
+      this.group.resume();
+    }
+  }
+
+  _onCommitComplete (info) {
+    this.buffered -= info.messagesCommitted;
+    if (!this.closing && this.group.paused && this.buffered <= this.options.prefetchLowWatermark) {
+      debug('resuming fetch because message backlog is below prefetchLowWatermark');
+      this.group.resume();
+    }
+  }
+
+  _onCommitRetry (err) {
+    //
+    // folks can listen for this event if they want insight into failed commits
+    //
+    this.emit('commit-retry', err);
+  }
+
+  _onInternalError (err) {
+    this.emit('error', err);
+  }
+
+  _onGroupMessage (msg, cb) {
+    if (this.idle) {
+      this.idle = false;
+    }
+
+    const topicPartition = `${msg.topic}/${msg.partition}`;
+    let partitionProcessor = this.partitionProcessors.get(topicPartition);
+    if (partitionProcessor == null) {
+      partitionProcessor = new PartitionProcessor(msg.topic, msg.partition, cb, this.commitManager, this.options);
+      partitionProcessor.on('error', err => this._onInternalError(err));
+      this.partitionProcessors.set(topicPartition, partitionProcessor);
+    }
+
+    if (partitionProcessor.push(msg)) {
+      this.buffered++;
+      if (!this.group.paused && this.buffered >= this.options.prefetchHighWatermark) {
+        debug('pausing fetch because message backlog exceeds prefetchHighWatermark');
+        this.group.pause();
+      }
+    }
+  }
+
+  _onGroupBatchDone () {
+    if (!this.idle) {
+      this.idle = true;
+      this.emit('internal:idle');
+    }
+  }
+}
+
+//
+// We extend ConsumerGroup only to neuter the commit/autoCommit methods & to capture assigned partitions.
+//
+// FIXME we directly access assignedPartitions elsewhere, but would be cleaner to add an isAssignedPartition method.
+//
+class InternalConsumerGroup extends ConsumerGroup {
+  constructor (options, topics) {
+    super(options, topics);
+    this.assignedPartitions = new Set();
+  }
+
+  commit (force, cb) {
+    if (typeof force === 'function') {
+      cb = force;
+      force = false;
+    }
+    setImmediate(cb);
+  }
+
+  autoCommit (force, cb) {
+    this.commit(force, cb);
+  }
+
+  handleSyncGroup (syncGroupResponse, callback) {
+    debug('handling sync group');
+    return super.handleSyncGroup(syncGroupResponse, (err, startFetch) => {
+      this.assignedPartitions = new Set();
+      if (!err) {
+        for (const [topic, partitions] of Object.entries(syncGroupResponse.partitions)) {
+          for (const partition of partitions) {
+            this.assignedPartitions.add(`${topic}/${partition}`);
+          }
+        }
+      }
+      debug('consumer was assigned partitions', Array.from(this.assignedPartitions));
+
+      callback(err, startFetch);
+    });
+  }
+}
+
+module.exports = AsyncConsumerGroup;

--- a/lib/asyncConsumerGroup/commitManager.js
+++ b/lib/asyncConsumerGroup/commitManager.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const EventEmitter = require('events');
+const retry = require('retry');
+const debug = require('debug')('kafka-node:asyncConsumerGroup:CommitManager');
+
+class CommitManager extends EventEmitter {
+  constructor (group, options) {
+    super();
+    this.group = group;
+    this.options = options;
+    this.offsets = new Map();
+    this.callbacks = [];
+    this.uncommitted = 0;
+    this.idle = true;
+  }
+
+  ack (message, cb) {
+    let partitionOffsets = this.offsets.get(message.topic);
+    if (!partitionOffsets) {
+      partitionOffsets = new Map();
+      this.offsets.set(message.topic, partitionOffsets);
+    }
+
+    partitionOffsets.set(message.partition, message.offset + 1);
+    if (cb) {
+      this.callbacks.push(cb);
+    }
+
+    this.uncommitted++;
+
+    //
+    // TODO need to support autoCommit-style intervals in addition to the more aggressive ConsumerGroupStream style too.
+    //
+    if (this.idle) {
+      this._commitPending();
+    }
+  }
+
+  acquiesce () {
+    return new Promise(resolve => {
+      if (this.idle) {
+        return resolve();
+      }
+      this.once('internal:idle', () => resolve());
+    });
+  }
+
+  purge () {
+    if (!this.idle) {
+      throw new Error('attempt to purge abandoned topic/partitions while consumer is committing');
+    }
+
+    this.offsets = new Map();
+    const reason = new Error('commit offsets purged');
+    for (const callback of this.callbacks) {
+      try {
+        callback(reason);
+      } catch (err) {
+        this.emit('error', err);
+      }
+    }
+    this.callbacks = [];
+  }
+
+  _commitPending () {
+    if (this.uncommitted === 0) {
+      debug('became idle');
+
+      this.idle = true;
+      this.emit('internal:idle');
+      return;
+    }
+
+    this.idle = false;
+
+    //
+    // if we don't retry "forever" we risk breaking the consumer, so override the user's preference here.
+    //
+    const overrides = {forever: true};
+    const retryOptions = Object.assign({}, this.options.commitRetryOptions, overrides);
+    const r = retry.operation(retryOptions);
+    r.attempt(() => this._attemptCommit(r));
+  }
+
+  _attemptCommit (r) {
+    //
+    // Take a snapshot of commits + callbacks before running the commit so we can discern which callbacks arrived while
+    // we were still committing.
+    //
+    const commits = this._buildCommits();
+    const callbacks = this.callbacks.slice();
+    const count = this.uncommitted;
+    debug('attempting offset commit for %d messages:', count, commits);
+    this.group.sendOffsetCommitRequest(commits, err => {
+      if (err) {
+        debug('commit attempt failed, retrying', err);
+        this.emit('internal:commit-retry', err);
+        r.retry(err);
+        return;
+      }
+
+      debug('commit successful, processing callbacks');
+      for (const callback of callbacks) {
+        try {
+          callback();
+        } catch (err) {
+          this.emit('error', err);
+        }
+      }
+      this.uncommitted -= count;
+      this.callbacks = this.callbacks.slice(callbacks.length);
+
+      this.emit('internal:commit-complete', {messagesCommitted: count});
+
+      //
+      // New commits may have arrived while we were committing.
+      //
+      setImmediate(() => this._commitPending());
+    });
+  }
+
+  _buildCommits () {
+    const commits = [];
+    for (const [topic, partitionCommits] of this.offsets.entries()) {
+      for (const [partition, offset] of partitionCommits.entries()) {
+        const metadata = 'm';
+        commits.push({topic, partition, offset, metadata});
+      }
+    }
+    return commits;
+  }
+}
+
+module.exports = CommitManager;

--- a/lib/asyncConsumerGroup/index.js
+++ b/lib/asyncConsumerGroup/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const AsyncConsumerGroup = require('./asyncConsumerGroup');
+
+module.exports = AsyncConsumerGroup;

--- a/lib/asyncConsumerGroup/partitionProcessor.js
+++ b/lib/asyncConsumerGroup/partitionProcessor.js
@@ -13,6 +13,8 @@ class PartitionProcessor extends EventEmitter {
     this.options = options;
     this.fn = fn;
     this.acquiescing = false;
+    this.uncommitted = 0;
+    this.backpressure = false;
     this.commitManager = commitManager;
 
     //
@@ -74,6 +76,8 @@ class PartitionProcessor extends EventEmitter {
     return new Promise(resolve => {
       let {message} = task;
 
+      this.uncommitted++;
+
       let acked = false;
       const ack = () => {
         debug('acking message at offset %d in %s/%d', message.offset, message.topic, message.partition);
@@ -90,17 +94,37 @@ class PartitionProcessor extends EventEmitter {
         }
 
         const commitPromise = new Promise(resolve => {
-          this.commitManager.ack(message, () => resolve());
+          this.commitManager.ack(message, () => {
+            this.uncommitted--;
+            if (this.backpressure && this.uncommitted < this.options.maxUncommittedMessages) {
+              debug('end backpressure on %s/%d', this.topic, this.partition);
+              this.backpressure = false;
+              this.emit('internal:backpressure-end');
+            }
+            resolve();
+          });
         });
 
         acked = true;
 
         //
-        // resolve on ack, not on commit: that's what the commitCallback (optional parameter to ack()) is for
+        // resolve on ack to start processing the next message while we wait for the current offset to commit.
         //
         // TODO set a ceiling on processed-but-not--yet-committed (see long comment up where _dispatchMessage is called)
         //
-        resolve();
+        const limit = this.options.maxUncommittedMessages;
+        if (this.uncommitted < limit) {
+          resolve();
+        } else if (!this.backpressure) {
+          //
+          // prevent further processing on this partition until we see some commits complete
+          //
+          const topic = this.topic;
+          const partition = this.partition;
+          debug('begin backpressure on %s/%d due to uncommitted message limit (%d messages)', topic, partition, limit);
+          this.backpressure = true;
+          this.once('internal:backpressure-end', () => resolve());
+        }
 
         return commitPromise;
       };

--- a/lib/asyncConsumerGroup/partitionProcessor.js
+++ b/lib/asyncConsumerGroup/partitionProcessor.js
@@ -75,7 +75,7 @@ class PartitionProcessor extends EventEmitter {
       let {message} = task;
 
       let acked = false;
-      const ack = (commitCallback) => {
+      const ack = () => {
         debug('acking message at offset %d in %s/%d', message.offset, message.topic, message.partition);
 
         //
@@ -89,7 +89,10 @@ class PartitionProcessor extends EventEmitter {
           return;
         }
 
-        this.commitManager.ack(message, commitCallback);
+        const commitPromise = new Promise(resolve => {
+          this.commitManager.ack(message, () => resolve());
+        });
+
         acked = true;
 
         //
@@ -98,6 +101,8 @@ class PartitionProcessor extends EventEmitter {
         // TODO set a ceiling on processed-but-not--yet-committed (see long comment up where _dispatchMessage is called)
         //
         resolve();
+
+        return commitPromise;
       };
       message = Object.assign({}, message, {ack});
 

--- a/lib/asyncConsumerGroup/partitionProcessor.js
+++ b/lib/asyncConsumerGroup/partitionProcessor.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const EventEmitter = require('events');
+const async = require('async');
+const retry = require('retry');
+const debug = require('debug')('kafka-node:asyncConsumerGroup:PartitionProcessor');
+
+class PartitionProcessor extends EventEmitter {
+  constructor (topic, partition, fn, commitManager, options) {
+    super();
+    this.topic = topic;
+    this.partition = partition;
+    this.options = options;
+    this.fn = fn;
+    this.acquiescing = false;
+    this.commitManager = commitManager;
+
+    //
+    // TODO may be useful to opt-in to more parallelism within a single partition if deliver order doesn't matter.
+    // Ideally users would simply just scale up the number of partitions to increase parallelism.
+    //
+    this.queue = async.queue((task, done) => {
+      //
+      // FIXME hard to tell async.queue "let me know when you're done with the current task, but process no more"
+      // hack around it in O(n), but a custom implementation could acquiesce in O(1) once the last task completes.
+      //
+      if (this.acquiescing) {
+        return done();
+      }
+
+      //
+      // TODO set a ceiling on processed-but-not--yet-committed messages by playing around with the call to done()
+      // or the call to resolve() or impl of ack() in dispatchMessage. This is super duper interesting in ways that
+      // may not be obvious at first glance.
+      //
+      // e.g. pipeline up to N messages before requiring an interleaving commit per partition; or e.g. require a commit
+      // per message for certain critical low volume topics where it might hurt to do unnecessary reprocessing. VERY
+      // USEFUL to have this sort of control. Folks will probably want to configure this either per topic, globally or
+      // both.
+      //
+      // The implementation won't by *hard* but it will be a little fiddly. Punting until we have some consensus on the
+      // general shape of this thing.
+      //
+      this._dispatchMessage(task)
+        .catch(err => {
+          this.emit('error', err);
+          done();
+        })
+        .then(() => done());
+    });
+    this.queue.drain = () => this.emit('internal:idle');
+    this.queue.error = err => this.emit('error', err);
+  }
+
+  push (msg) {
+    if (this.acquiescing) {
+      return false;
+    }
+    this.queue.push({message: msg});
+    return true;
+  }
+
+  acquiesce () {
+    return new Promise(resolve => {
+      this.acquiescing = true;
+      if (this.queue.idle()) {
+        return resolve();
+      }
+      this.once('internal:idle', () => resolve());
+    });
+  }
+
+  _dispatchMessage (task) {
+    return new Promise(resolve => {
+      let {message} = task;
+
+      let acked = false;
+      const ack = (commitCallback) => {
+        debug('acking message at offset %d in %s/%d', message.offset, message.topic, message.partition);
+
+        //
+        // Attempts to ack the same message twice should be treated as a bug -- probably in user code -- since it means
+        // there's still something out there trying to process this message in spite of the fact we've moved on to
+        // processing other messages. All internal attempts to implicitly ack for one reason or another should check
+        // `acked` before calling ack().
+        //
+        if (acked) {
+          this.emit('error', new Error('detected multiple attempts to ack the same message'));
+          return;
+        }
+
+        this.commitManager.ack(message, commitCallback);
+        acked = true;
+
+        //
+        // resolve on ack, not on commit: that's what the commitCallback (optional parameter to ack()) is for
+        //
+        // TODO set a ceiling on processed-but-not--yet-committed (see long comment up where _dispatchMessage is called)
+        //
+        resolve();
+      };
+      message = Object.assign({}, message, {ack});
+
+      //
+      // Make multiple attempts to retry in the event processing fails.
+      //
+      // TODO does this belong in kafka-node? Could be lifted into user code, but the retry semantics are often useful.
+      //
+      const r = retry.operation(this.options.processRetryOptions);
+
+      const maybeRetry = err => {
+        if (r.retry(err)) {
+          return;
+        }
+
+        //
+        // Be extra paranoid about errors here in the unlikely scenario ack() is the thing throwing.
+        //
+        // TODO instead of ack() (which changes offsets & triggers commit), maybe just skip without bumping offsets?
+        //
+        if (!acked) {
+          try {
+            ack();
+          } catch (err) {
+            this.emit('error', err);
+          }
+        }
+
+        this.emit('error', r.mainError());
+      };
+
+      r.attempt(() => {
+        debug('attempting to process message at offset %d in %s/%d', message.offset, message.topic, message.partition);
+        let promise;
+        try {
+          promise = this.fn(message);
+        } catch (err) {
+          return maybeRetry(err);
+        }
+
+        //
+        // If the value returned from fn() looks & smells like a promise & smells & it hasn't already been acked, ack()
+        // when the promise resolves; retry processing on catch.
+        //
+        if (promise && promise.then) {
+          promise
+            .then(() => {
+              if (!acked) {
+                ack();
+              }
+            })
+            .catch(err => maybeRetry(err));
+        }
+      });
+    });
+  }
+}
+
+module.exports = PartitionProcessor;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test": "eslint . && npm run test:ts && ./run-tests.sh && nsp check",
     "startDocker": "./start-docker.sh",
     "stopDocker": "docker-compose down",
-    "updateToc": "doctoc README.md --maxlevel 2 --notitle"
+    "updateToc": "doctoc README.md --maxlevel 2 --notitle",
+    "v4": "exec node v4_example.js"
   }
 }


### PR DESCRIPTION
@hyperlink @aikar thought I'd put together something for discussion RE: async message processing in consumers & addressing some of the limitations of `ConsumerGroup` and `ConsumerGroupStream`. This is just a proof of concept so very rough around the edges, it's probably riddled with bugs and if we throw this away in favor of something more suitable that's totally fine. I was hoping to get this up before 3.x shipped, but it's probably too big to squeeze in at the last minute anyway.

The problems I'm trying to solve here are mostly in relation to `ConsumerGroupStream` and `ConsumerGroup` since that's "the future", but apply just as much to the older ZK stuff I think.

Example output from `example/async.js` in case it helps you follow along in the code: https://gist.githubusercontent.com/thomaslee/3f60249e82322f1d7edba57d061c252f/raw/dc2193f6d57e016db961d4744fa0bf16ad3fa3dc/output.txt

## Implemented

1. **Async message processing "for free".** `ConsumerGroup` obviously doesn't support this at all out of the box without some careful finagling. `ConsumerGroupStream` takes care of _some_ of that finagling, but it's still easy for users to make mistakes (e.g. somebody not paying attention could attempt to commit offset 3 after previously committing offset 5).
2. **Parallelism at the partition level "for free".** Slow processing of a message on topic/partition A/1 (e.g. a large file, a slow database/web service, whatever) will not slow down processing on topic/partitions A/2 or B/3.
3. **In-order processing at the partition level "for free".** This one is a bit more subtle: `ConsumerGroupStream` makes it possible, but it's another one that's easy to get wrong if you're not paying attention. In `AsyncConsumerGroup` you need to explicitly `ack()` a message or resolve a promise/`async` method to indicate that you're ready to process the next message on a partition.
4. **_Acquiesce_ and commit before a rebalance/close.** The `acquiesce` methods you see wait for processing to reach a "quiet" state & then waits for pending commits to complete prior to allowing a rebalance to occur. The existing commit logic in `ConsumerGroup` is a bit more haphazard in that it can't really ensure that all processing is complete before rebalances etc. occur. `ConsumerGroupStream` does better, but falls back to `ConsumerGroup` semantics in certain important cases.
5. **Throttling of fetches with watermarks** `ConsumerGroupStream` throttles by batches, which can mean we're waiting for fetches when we could be processing. The watermarks allow us to fetch more aggressively up to some limit (`prefetchHighWatermark`) and then wait for processing to reduce the backlog below some floor value (`prefetchLowWatermark`) before we start fetching again. The result is theoretically a bit less "thrashy" & should ensure less idle time that could be spent processing messages. Even better than this would be the "Partition-aware fetching" described below.

## Not implemented but fairly trivial

1. **Upper bounds on "processed-but-not-yet-committed" messages.** Network issues or cluster outages can prevent consumers from committing offsets. While that's happening, existing consumer implementations will charge forward and process however many messages have been previously fetched. This can lead to large amounts of "reprocessing" when the consumer finally makes contact with the cluster again & goes through a storm of rebalances. It would be fairly trivial to set an upper bound on this per partition, per topic and/or per consumer to minimize reprocessing. Useful for use cases where reprocessing "hurts" & there's a desire to keep it to a minimum. If you want to make sure you're never 1 message ahead of what's been committed & don't mind the throughput hit, that's fine. **(EDIT: now implemented)**
2. **Commit on an interval (`autoCommit`) instead of on completion of processing.** I personally don't think there's a huge problem with just committing immediately after processing a message & relying on the natural throttling that occurs in high volume topics/partitions, but some folks prefer to commit on an interval. This would be easy to wire up in `CommitManager`. My understanding is this is at best difficult to do correctly with the current `ConsumerGroupStream` API.

## Not implemented & difficult (4.x? :wink:)

These typically involve large or tricky changes to KafkaClient/ConsumerGroup internals.

1. **Unified consumer API.**  I'm sort of loathe to add _yet another_ consumer class & feel like longer term we should consolidate around a unified consumer & producer with pluggable "details" (e.g. ZKCommitManager vs. KafkaCommitManager). I think the `consume(cb)` API would work for both synchronous & asynchronous message processing, though `msg.ack()` is a bit meaningless in synchronous processing. Perhaps async processing would be "good enough" for synchronous use cases.
2. **Partition-aware fetching.** Unless you're very lucky, some topic/partitions will be significantly busier (or take more time to process) than others. The `PartitionProcessor`s know when they're about to run out of work & could inform the code that handles fetching that they're going to need more work soon. This ensures that we can keep processing all partitions even if one partition lags behind.

## Roadmap?

If we're okay with adding the extra consumer class, **I'd love to see something like this land in a hypothetical 3.1.0/3.2.0** -- mostly because I'd sleep a lot easier knowing that our internal users aren't reliant on some internal dirty hacks around kafka-node. 😄 But obviously plenty to discuss here.

## Summary

Hopefully you guys can ignore the warts of the actual implementation & see what I'm shooting for here. Kafka's partitions are the key to safely parallelizing message processing & by treading carefully we can maximize async message processing performance, minimize "reprocessing" that can occur due to rebalances or faults, keep Kafka's delivery order guarantees at the partition level in  a way that's trivial for end users.

And again, probably bugs galore and I've probably got certain things hopelessly wrong -- feel free to comment on the code if something's unclear, but I'm more interested in discussing the *spirit* of the change & the broad strokes of the design/API. I'm not attached to the implementation, but I am very attached to addressing the problems it solves. 😄 If we can do all of this with less code & a drastically different API, that's totally fine by me.

## Example usage

Putting this way down the bottom because the API isn't the interesting part of this IMO, but see `example/async.js` for a full example if you'd like something to play with:

```javascript
const consumer = new kafka.AsyncConsumerGroup(options, 'kafka-node-demo');
consumer.on('error', err => ...);

//
// callback is invoked per message, next message processed after msg.ack()
// return a promise & msg.ack() will be implicitly called when the promise resolves.
//
consumer.consume(msg => {
  console.log(JSON.stringify(msg));
  doSomethingAsync().then(() => msg.ack());
});
// later: consumer.close().then(() => process.exit(0));
```
