### PR TITLE
Multiple fixes to message ordering and compression, Fixes #298

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -191,8 +191,11 @@ function decodeValue (encoding, value) {
   return value;
 }
 
-Client.prototype._createMessageHandler = function (consumer) {
+Client.prototype._createMessageHandler = function (consumer, stateValidator) {
   return (err, type, message) => {
+    if (stateValidator && !stateValidator(err, type, message)) {
+      return;
+    }
     if (err) {
       if (err.message === 'OffsetOutOfRange') {
         return consumer.emit('offsetOutOfRange', err);
@@ -212,13 +215,14 @@ Client.prototype._createMessageHandler = function (consumer) {
 
       consumer.emit('message', message);
     } else {
-      consumer.emit('done', message);
+      consumer.emit(type, message);
     }
   };
 };
 
 Client.prototype.sendFetchRequest = function (consumer, payloads, fetchMaxWaitMs, fetchMinBytes, maxTickMessages) {
   var encoder = protocol.encodeFetchRequest(fetchMaxWaitMs, fetchMinBytes);
+  // TODO: state validator for HLC for ignoring stale fetch requests
   var decoder = protocol.decodeFetchResponse(this._createMessageHandler(consumer), maxTickMessages);
 
   this.send(payloads, encoder, decoder, function (err) {

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -182,15 +182,11 @@ function ConsumerGroup (memberOptions, topics) {
     });
   });
 
-  // 'done' will be emit when a message fetch request complete
-  this.on('done', function (topics) {
-    self.updateOffsets(topics);
-    if (!self.paused) {
-      setImmediate(function () {
-        self.fetch();
-      });
-    }
-  });
+  this._pendingFetches = 0;
+  // 'processingfetch' emits before we start processing new messages
+  // 'done' will be emit when all messages are done emitting
+  this.on('processingfetch', () => this._onFetchProcessing());
+  this.on('done', (topics) => this._onFetchDone(topics));
 
   if (this.options.groupId) {
     validateConfig('options.groupId', this.options.groupId);
@@ -201,6 +197,7 @@ function ConsumerGroup (memberOptions, topics) {
   this.generationId = null;
   this.ready = false;
   this.topicPayloads = [];
+  this.payloadMap = {};
 }
 
 util.inherits(ConsumerGroup, HighLevelConsumer);
@@ -475,6 +472,7 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
             p.offset = offset;
             return p;
           });
+          self.payloadMap = self.buildPayloadMap(self.topicPayloads);
           if (noOffset && self.options.commitOffsetsOnFirstJoin) {
             self.commit(true, err => {
               callback(err, !err ? true : null);
@@ -488,6 +486,7 @@ ConsumerGroup.prototype.handleSyncGroup = function (syncGroupResponse, callback)
     );
   } else {
     self.topicPayloads = [];
+    self.payloadMap = {};
     // no partitions assigned
     callback(null, false);
   }
@@ -607,6 +606,7 @@ ConsumerGroup.prototype.connect = function () {
       logger.debug('generationId', self.generationId);
 
       logger.debug('startFetch is', startFetch);
+      self._resetFetchState();
       if (startFetch) {
         self.clearPendingFetches();
         self.fetch();

--- a/lib/consumerStream.js
+++ b/lib/consumerStream.js
@@ -137,7 +137,7 @@ ConsumerStream.prototype.decodeCallback = function (err, type, message) {
       message.value = message.value.toString(encoding);
     }
     this.handleMessage(message);
-  } else {
+  } else if (type === 'done') {
     // If we had neither error nor message, this is the end of a fetch,
     // and we should update the offset for the next fetch.
     this.updateOffsets(message);

--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -56,6 +56,7 @@ var HighLevelConsumer = function (client, topics, options) {
   this.needToCommit = false;
   this.id = this.options.id || this.options.groupId + '_' + uuid.v4();
   this.payloads = this.buildPayloads(topics);
+  this.payloadMap = this.buildPayloadMap(this.payloads);
   this.topicPayloads = this.buildTopicPayloads(topics);
   this.connect();
 
@@ -75,6 +76,15 @@ HighLevelConsumer.prototype.buildPayloads = function (payloads) {
     p.metadata = 'm'; // metadata can be arbitrary
     return p;
   });
+};
+
+HighLevelConsumer.prototype.buildPayloadMap = function (payloads) {
+  const payloadMap = {};
+  payloads.forEach(({topic, partition, offset}) => {
+    payloadMap[topic] = payloadMap[topic] || {};
+    payloadMap[topic][partition] = offset;
+  });
+  return payloadMap;
 };
 
 // Initially this will always be empty - until after a re-balance
@@ -187,6 +197,7 @@ HighLevelConsumer.prototype.connect = function () {
           }
           if (err) {
             self.rebalancing = false;
+            self._resetFetchState();
             return self.emit('error', new errors.FailedToRebalanceConsumerError(operation.mainError().toString()));
           } else {
             var topicNames = self.topicPayloads.map(function (p) {
@@ -196,6 +207,7 @@ HighLevelConsumer.prototype.connect = function () {
               register();
               if (err) {
                 self.rebalancing = false;
+                self._resetFetchState();
                 self.emit('error', err);
                 return;
               }
@@ -203,6 +215,7 @@ HighLevelConsumer.prototype.connect = function () {
               if (self.topicPayloads.length) {
                 fetchAndUpdateOffsets(function (err) {
                   self.rebalancing = false;
+                  self._resetFetchState();
                   if (err) {
                     self.emit('error', new errors.FailedToRebalanceConsumerError(err.message));
                     return;
@@ -212,6 +225,7 @@ HighLevelConsumer.prototype.connect = function () {
                 });
               } else { // was not assigned any partitions during rebalance
                 self.rebalancing = false;
+                self._resetFetchState();
                 self.emit('rebalanced');
               }
             });
@@ -314,15 +328,11 @@ HighLevelConsumer.prototype.connect = function () {
     });
   });
 
-  // 'done' will be emit when a message fetch request complete
-  this.on('done', function (topics) {
-    self.updateOffsets(topics);
-    if (!self.paused) {
-      setImmediate(function () {
-        self.fetch();
-      });
-    }
-  });
+  this._pendingFetches = 0;
+  // 'processingfetch' emits before we start processing new messages
+  // 'done' will be emit when all messages are done emitting
+  this.on('processingfetch', () => this._onFetchProcessing());
+  this.on('done', (topics) => this._onFetchDone(topics));
 };
 
 HighLevelConsumer.prototype._releasePartitions = function (topicPayloads, callback) {
@@ -534,8 +544,11 @@ HighLevelConsumer.prototype.updateOffsets = function (topics, initing) {
       if (offset === -1) offset = 0;
       if (!initing) p.offset = offset + 1;
       else p.offset = offset;
+      // Update the map
       this.needToCommit = true;
     }
+    this.payloadMap[p.topic] = this.payloadMap[p.topic] || {};
+    this.payloadMap[p.topic][p.partition] = p.offset;
   });
 
   if (this.options.autoCommit && !initing) {
@@ -580,6 +593,10 @@ HighLevelConsumer.prototype.fetch = function () {
   if (!this.ready || this.rebalancing || this.paused || this.closing) {
     return;
   }
+  if (this._isFetchPending) {
+    return;
+  }
+  this._isFetchPending = true;
 
   this.client.sendFetchRequest(
     this,
@@ -588,6 +605,26 @@ HighLevelConsumer.prototype.fetch = function () {
     this.options.fetchMinBytes,
     this.options.maxTickMessages
   );
+};
+
+HighLevelConsumer.prototype._resetFetchState = function () {
+  this._pendingFetches = 0;
+  this._isFetchPending = false;
+};
+
+HighLevelConsumer.prototype._onFetchProcessing = function () {
+  this._pendingFetches++;
+};
+
+HighLevelConsumer.prototype._onFetchDone = function (topics) {
+  this.updateOffsets(topics);
+  if (--this._pendingFetches > 0) {
+    return;
+  }
+  this._isFetchPending = false;
+  if (!this.paused) {
+    setImmediate(() => this.fetch());
+  }
 };
 
 HighLevelConsumer.prototype.fetchOffset = function (payloads, cb) {
@@ -648,6 +685,7 @@ HighLevelConsumer.prototype.addTopics = function (topics, cb) {
           p.offset = offset;
           self.topicPayloads.push(p);
         });
+        self.payloadMap = self.buildPayloadMap(self.topicPayloads);
         // TODO: rebalance consumer
         cb && cb(null, added);
       });

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1128,7 +1128,7 @@ KafkaClient.prototype.sendFetchRequest = function (
   payloads = _.cloneDeep(payloads);
   const memberId = consumer.memberId;
   const generationId = consumer.generationId;
-  function stateValidator (err, type, message) {
+  function stateValidator (unused, type, message) {
     const payloadMap = consumer.payloadMap;
     if (consumer.closing || consumer.connecting || consumer.rebalancing || consumer.memberId !== memberId || consumer.generationId !== generationId) {
       logger.error('ignoring message due to it being from an old group - memberId: ' + memberId, '!=' + consumer.memberId + ' - generationId: ' + generationId + '!=' + consumer.generationId);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1137,6 +1137,7 @@ KafkaClient.prototype.sendFetchRequest = function (
     if (type === 'message') {
       const {topic, partition, offset} = message;
       if (!payloadMap[topic] || payloadMap[topic][partition] == null) {
+        logger.error('received unexpected message', message, payloadMap);
         // We should have never received this in the first place
         return false;
       }

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1125,6 +1125,30 @@ KafkaClient.prototype.sendFetchRequest = function (
   maxTickMessages,
   callback
 ) {
+  payloads = _.cloneDeep(payloads);
+  const memberId = consumer.memberId;
+  const generationId = consumer.generationId;
+  function stateValidator (err, type, message) {
+    const payloadMap = consumer.payloadMap;
+    if (consumer.closing || consumer.connecting || consumer.rebalancing || consumer.memberId !== memberId || consumer.generationId !== generationId) {
+      logger.error('ignoring message due to it being from an old group - memberId: ' + memberId, '!=' + consumer.memberId + ' - generationId: ' + generationId + '!=' + consumer.generationId);
+      return false;
+    }
+    if (type === 'message') {
+      const {topic, partition, offset} = message;
+      if (!payloadMap[topic] || payloadMap[topic][partition] == null) {
+        // We should have never received this in the first place
+        return false;
+      }
+
+      if (offset == null || offset < payloadMap[topic][partition]) {
+        // Kafka may send an older message than we expect (compressed messages, and other unknown reasons)
+        return false;
+      }
+    }
+
+    return true;
+  }
   if (callback == null) {
     callback = _.noop;
   }
@@ -1141,7 +1165,7 @@ KafkaClient.prototype.sendFetchRequest = function (
           data: {
             payloads: payloads,
             args: [fetchMaxWaitMs, fetchMinBytes],
-            decoderArgs: [this._createMessageHandler(consumer), maxTickMessages]
+            decoderArgs: [this._createMessageHandler(consumer, stateValidator), maxTickMessages]
           }
         };
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -13,7 +13,7 @@ var PartitionMetadata = protocol.PartitionMetadata;
 const API_KEY_TO_NAME = _.invert(REQUEST_TYPE);
 const MessageSizeTooLarge = require('../errors/MessageSizeTooLargeError');
 const SaslAuthenticationError = require('../errors/SaslAuthenticationError');
-const async = require("async");
+const async = require('async');
 
 var API_VERSION = 0;
 var REPLICA_ID = -1;
@@ -241,6 +241,9 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
   // topics is not ready for use until all events are processed, as an async
   // decompression may add more offsets to the topic map.
   async.series(events, (err) => {
+    if (err) {
+      cb(err);
+    }
     cb(null, 'done', topics);
   });
 
@@ -254,9 +257,9 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
       .tap(function (vars) {
         this.buffer('messageSet', vars.messageSetSize);
         if (vars.errorCode !== 0) {
-          // eslint-disable-next-line standard/no-callback-literal
           return events.push((next) => {
-            emit({ topic: vars.topic, partition: vars.partition, message: ERROR_CODE[vars.errorCode] });
+            // eslint-disable-next-line standard/no-callback-literal
+            cb({ topic: vars.topic, partition: vars.partition, message: ERROR_CODE[vars.errorCode] });
             next();
           });
         }
@@ -287,7 +290,6 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
 
 function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickMessages, highWaterOffset, topics, base) {
   var set = [];
-  var messageCount = 0;
   const messageSetSize = messageSet.length;
   while (messageSet.length > 0) {
     var cur = 8 + 4 + 4 + 1 + 1 + 4 + 4;
@@ -339,7 +341,6 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickM
         }
 
         if (!partial && vars.offset !== null) {
-          messageCount++;
           vars.offset += (base || 0);
           set.push(vars.offset);
           var codec = getCodec(vars.attributes);
@@ -358,8 +359,8 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickM
             }
 
             return enqueue((next) => {
-                emit(null, 'message', message);
-                next(null);
+              emit(null, 'message', message);
+              next(null);
             });
           }
           enqueue((next) => {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -250,6 +250,7 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
   function decodePartitions (end, vars) {
     if (--vars.partitionNum === 0) end();
     topics[vars.topic] = topics[vars.topic] || {};
+    let hadError = false;
     this.word32bs('partition')
       .word16bs('errorCode')
       .word64bs('highWaterOffset')
@@ -263,9 +264,14 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
             next();
           });
         }
-        var messageSet = decodeMessageSet(
-          vars.topic,
-          vars.partition,
+
+        const topic = vars.topic;
+        const partition = vars.partition;
+        const highWaterOffset = vars.highWaterOffset;
+
+        decodeMessageSet(
+          topic,
+          partition,
           vars.messageSet,
           (enqueuedTask) => {
             events.push(enqueuedTask);
@@ -274,23 +280,34 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
               events.push((next) => process.nextTick(next));
             }
           },
-          cb,
-          maxTickMessages,
-          vars.highWaterOffset,
+          (err, data) => {
+            if (err) {
+              hadError = true;
+            } else if (hadError) {
+              return; // Once we've had an error on this partition, don't emit any more messages
+            }
+            if (!err && data) {
+              topics[topic][partition] = data.offset;
+
+              cb(null, 'message', data);
+            } else {
+              cb(err);
+            }
+          },
+          highWaterOffset,
           topics,
           0 // base offset
         );
-        if (messageSet.length) {
-          topics[vars.topic][vars.partition] = messageSet[messageSet.length - 1];
-          topics[vars.topic].highWaterOffset = vars.highWaterOffset;
-        }
       });
   }
 }
 
-function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickMessages, highWaterOffset, topics, base) {
-  var set = [];
+function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWaterOffset, topics, base) {
   const messageSetSize = messageSet.length;
+  // TODO: this is broken logic. It overwrites previous partitions HWO.
+  // Need to refactor this on next major API bump
+  topics[topic].highWaterOffset = highWaterOffset;
+
   while (messageSet.length > 0) {
     var cur = 8 + 4 + 4 + 1 + 1 + 4 + 4;
     var partial = false;
@@ -342,7 +359,6 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickM
 
         if (!partial && vars.offset !== null) {
           vars.offset += (base || 0);
-          set.push(vars.offset);
           var codec = getCodec(vars.attributes);
           if (!codec) {
             const message = {
@@ -359,23 +375,23 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickM
             }
 
             return enqueue((next) => {
-              emit(null, 'message', message);
+              emit(null, message);
               next(null);
             });
           }
           enqueue((next) => {
             codec.decode(vars.value, function (error, inlineMessageSet) {
-              if (error) emit(error);
-              const innerSetResult = decodeMessageSet(topic, partition, inlineMessageSet, (cb) => {
-                cb(_.noop);
-              }, emit, maxTickMessages, highWaterOffset, topics, vars.offset);
-
-              if (innerSetResult.length) {
-                topics[topic][partition] = innerSetResult[innerSetResult.length - 1];
-                topics[topic].highWaterOffset = vars.highWaterOffset;
+              if (error) {
+                emit(error);
+                next(null);
+                return;
               }
+              decodeMessageSet(topic, partition, inlineMessageSet, (cb) => {
+                cb(_.noop);
+              }, emit, highWaterOffset, topics, vars.offset);
 
-              next(null);
+              // Delay 1 tick as this isn't counted to max tick messages, give a breather
+              process.nextTick(() => next(null));
             });
           });
         }
@@ -384,7 +400,6 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickM
     if (partial) break;
     messageSet = messageSet.slice(cur);
   }
-  return set;
 }
 
 function encodeMetadataRequest (clientId, correlationId, topics) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -257,10 +257,15 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
       .word32bs('messageSetSize')
       .tap(function (vars) {
         this.buffer('messageSet', vars.messageSetSize);
-        if (vars.errorCode !== 0) {
+        const errorCode = vars.errorCode;
+        if (errorCode !== 0) {
+          const topic = vars.topic;
+          const partition = vars.partition;
           return events.push((next) => {
-            // eslint-disable-next-line standard/no-callback-literal
-            cb({ topic: vars.topic, partition: vars.partition, message: ERROR_CODE[vars.errorCode] });
+            const err = new Error(ERROR_CODE[errorCode]);
+            err.topic = topic;
+            err.partition = partition;
+            cb(err);
             next();
           });
         }

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -352,10 +352,11 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
         }
 
         if (vars.attributes === 0 && vars.messageSize > messageSetSize) {
+          const offset = vars.offset;
           return enqueue((next) => {
             emit(new MessageSizeTooLarge({
               topic: topic,
-              offset: vars.offset,
+              offset: offset,
               partition: partition
             }));
             next(null);
@@ -363,16 +364,18 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
         }
 
         if (!partial && vars.offset !== null) {
-          vars.offset += (base || 0);
+          const offset = vars.offset + (base || 0);
+          const value = vars.value;
+          const key = vars.key;
           var codec = getCodec(vars.attributes);
           if (!codec) {
             const message = {
               topic: topic,
-              value: vars.value,
-              offset: vars.offset,
+              value: value,
+              offset: offset,
               partition: partition,
               highWaterOffset: highWaterOffset,
-              key: vars.key
+              key: key
             };
 
             if (vars.timestamp) {
@@ -385,7 +388,7 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
             });
           }
           enqueue((next) => {
-            codec.decode(vars.value, function (error, inlineMessageSet) {
+            codec.decode(value, function (error, inlineMessageSet) {
               if (error) {
                 emit(error);
                 next(null);
@@ -393,7 +396,7 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
               }
               decodeMessageSet(topic, partition, inlineMessageSet, (cb) => {
                 cb(_.noop);
-              }, emit, highWaterOffset, topics, vars.offset);
+              }, emit, highWaterOffset, topics, offset);
 
               // Delay 1 tick as this isn't counted to max tick messages, give a breather
               process.nextTick(() => next(null));

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -13,6 +13,7 @@ var PartitionMetadata = protocol.PartitionMetadata;
 const API_KEY_TO_NAME = _.invert(REQUEST_TYPE);
 const MessageSizeTooLarge = require('../errors/MessageSizeTooLargeError');
 const SaslAuthenticationError = require('../errors/SaslAuthenticationError');
+const async = require("async");
 
 var API_VERSION = 0;
 var REPLICA_ID = -1;
@@ -214,7 +215,15 @@ function createGroupError (errorCode) {
 }
 
 function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
+  if (!cb) {
+    throw new Error('Missing callback');
+  }
+
   var topics = {};
+  var events = [];
+  let eventCount = 0;
+
+  cb(null, 'processingfetch');
   Binary.parse(resp)
     .word32bs('size')
     .word32bs('correlationId')
@@ -225,6 +234,15 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
     })
     .word32bs('topicNum')
     .loop(decodeTopics(decodePartitions));
+
+  // Parsing is all sync, but emitting events is async due to compression
+  // At this point, the enqueue chain should be populated in order, and at
+  // the end, the 'topics' map above should be fully populated.
+  // topics is not ready for use until all events are processed, as an async
+  // decompression may add more offsets to the topic map.
+  async.series(events, (err) => {
+    cb(null, 'done', topics);
+  });
 
   function decodePartitions (end, vars) {
     if (--vars.partitionNum === 0) end();
@@ -237,27 +255,37 @@ function _decodeFetchResponse (resp, cb, maxTickMessages, version) {
         this.buffer('messageSet', vars.messageSetSize);
         if (vars.errorCode !== 0) {
           // eslint-disable-next-line standard/no-callback-literal
-          return cb({ topic: vars.topic, partition: vars.partition, message: ERROR_CODE[vars.errorCode] });
+          return events.push((next) => {
+            emit({ topic: vars.topic, partition: vars.partition, message: ERROR_CODE[vars.errorCode] });
+            next();
+          });
         }
         var messageSet = decodeMessageSet(
           vars.topic,
           vars.partition,
           vars.messageSet,
+          (enqueuedTask) => {
+            events.push(enqueuedTask);
+            if (maxTickMessages && ++eventCount >= maxTickMessages) {
+              eventCount = 0;
+              events.push((next) => process.nextTick(next));
+            }
+          },
           cb,
           maxTickMessages,
-          vars.highWaterOffset
+          vars.highWaterOffset,
+          topics,
+          0 // base offset
         );
         if (messageSet.length) {
-          var offset = messageSet[messageSet.length - 1];
-          topics[vars.topic][vars.partition] = offset;
+          topics[vars.topic][vars.partition] = messageSet[messageSet.length - 1];
           topics[vars.topic].highWaterOffset = vars.highWaterOffset;
         }
       });
   }
-  cb && cb(null, 'done', topics);
 }
 
-function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, highWaterOffset) {
+function decodeMessageSet (topic, partition, messageSet, enqueue, emit, maxTickMessages, highWaterOffset, topics, base) {
   var set = [];
   var messageCount = 0;
   const messageSetSize = messageSet.length;
@@ -300,20 +328,20 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
         }
 
         if (vars.attributes === 0 && vars.messageSize > messageSetSize) {
-          cb(
-            new MessageSizeTooLarge({
+          return enqueue((next) => {
+            emit(new MessageSizeTooLarge({
               topic: topic,
               offset: vars.offset,
               partition: partition
-            })
-          );
-          return;
+            }));
+            next(null);
+          });
         }
 
         if (!partial && vars.offset !== null) {
           messageCount++;
+          vars.offset += (base || 0);
           set.push(vars.offset);
-          if (!cb) return;
           var codec = getCodec(vars.attributes);
           if (!codec) {
             const message = {
@@ -329,18 +357,30 @@ function decodeMessageSet (topic, partition, messageSet, cb, maxTickMessages, hi
               message.timestamp = new Date(vars.timestamp);
             }
 
-            return cb(null, 'message', message);
+            return enqueue((next) => {
+                emit(null, 'message', message);
+                next(null);
+            });
           }
-          codec.decode(vars.value, function (error, inlineMessageSet) {
-            if (error) return; // Not sure where to report this
-            decodeMessageSet(topic, partition, inlineMessageSet, cb, maxTickMessages, highWaterOffset);
+          enqueue((next) => {
+            codec.decode(vars.value, function (error, inlineMessageSet) {
+              if (error) emit(error);
+              const innerSetResult = decodeMessageSet(topic, partition, inlineMessageSet, (cb) => {
+                cb(_.noop);
+              }, emit, maxTickMessages, highWaterOffset, topics, vars.offset);
+
+              if (innerSetResult.length) {
+                topics[topic][partition] = innerSetResult[innerSetResult.length - 1];
+                topics[topic].highWaterOffset = vars.highWaterOffset;
+              }
+
+              next(null);
+            });
           });
         }
       });
     // Skip decoding binary left in the message set if partial message detected
     if (partial) break;
-    // Defensive code around potential denial of service
-    if (maxTickMessages && messageCount > maxTickMessages) break;
     messageSet = messageSet.slice(cur);
   }
   return set;

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -352,7 +352,7 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
         }
 
         if (vars.attributes === 0 && vars.messageSize > messageSetSize) {
-          const offset = vars.offset;
+          const offset = vars.offset + (base || 0);
           return enqueue((next) => {
             emit(new MessageSizeTooLarge({
               topic: topic,


### PR DESCRIPTION
There was numerous risks with the fetch process resolved here.

1) Compressed messages, as mentioned in #298, would be guaranteed out of order
We resolve this by making fetch response buffering be handled through a chain
of executions, where one partition is not emitted until the previous one is done,
and able to be processed asynchronously.

This however introduces new risk as the system only dealt with synchronous
processing before, meaning 2 fetch buffers could not be processing at the same
time. But because it's now async, we could end up processing multiple.

We now need to guard starting a new fetch while one is still processing, to ensure
that a new fetch does not begin with stale offset data.

2) Fetch requests may start, and end up being long polling. This fetch result may
end up coming back after a rebalance, or disconnection from the group occurred.

Those fetch requests would then emit events, which may be at different
offsets, topics, or partitions than the new consumer group membership is responsible for...

So if you received an old fetch response for a topic/partition you are no longer
responsible for, you would receive errors. Or even worse, if you are still responsible
for this partition, you may receive a message that about to be received in the new
memberships fetch request.

We will now run a state validator on the message handler to ensure our group
membership has not changed since the fetch request started, and ignore the response
if it has.

3) Kafka, for some unknown reasons, and one known, in the case of compression,
can return an offset older than the offset you requested.

This is a message we know we have already emitted if our topic payloads already
contained this offset.

We need to skip this message, and any message that shouldn't of been in the response
in the first place should we of received an abnormal response, to guarantee data accuracy.