### PR TITLE
Type of message key could be Buffer when using Avro schema serialization and deserialization

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -138,7 +138,7 @@ export class Offset {
 }
 
 export class KeyedMessage {
-  constructor (key: string, value: string | Buffer);
+  constructor (key: string | Buffer, value: string | Buffer);
 }
 
 export class ProducerStream extends Writable {
@@ -161,7 +161,12 @@ export interface Message {
   offset?: number;
   partition?: number;
   highWaterOffset?: number;
-  key?: string;
+  key?: string | Buffer;
+}
+
+export interface KeyedMessage {
+  key: string | Buffer;
+  value: string | Buffer;
 }
 
 export interface ProducerOptions {
@@ -208,7 +213,7 @@ export interface ZKOptions {
 export interface ProduceRequest {
   topic: string;
   messages: any; // string[] | Array<KeyedMessage> | string | KeyedMessage
-  key?: string;
+  key?: string | Buffer;
   partition?: number;
   attributes?: number;
 }
@@ -310,4 +315,4 @@ export class TopicsNotExistError extends Error {
   topics: string | string[];
 }
 
-export type CustomPartitioner = (partitions: number[], key: any) => number;
+export type CustomPartitioner = (partitions: number[], key: string | Buffer) => number;


### PR DESCRIPTION
This PR is basically an update for type definitions. When using Avro schema serialization and desrialization, types of message key or value could be buffer. This is also a type catch-up for #932 