### PR TITLE
add support for DescribeConfigs protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,83 @@ admin.createTopics(topics, (err, res) => {
 
 See [createTopics](#createtopicstopics-cb)
 
+### describeConfigs(payload, cb)
+
+Fetch the configuration for the specified resources. It requires Kafka 0.11+.
+
+* `payload`: **Array**, array of resources
+* `cb`: **Function**, the callback
+
+Example:
+
+```js
+const resource = {
+  resourceType: '2',        // '2' for topic, '4' for broker
+  resourceName: 'my-topic-name',
+  configNames: []           // specific config names, or empty array to return all,
+  includeSynonyms: false,   // requires kafka 2.0+
+}
+
+admin.describeConfigs([resource], (err, res) => {
+  console.log(JSON.stringify(res,null,1));
+})
+```
+
+Result:
+
+```json
+[
+ {
+  "configEntries": [
+   {
+    "synonyms": [],
+    "configName": "compression.type",
+    "configValue": "producer",
+    "readOnly": false,
+    "configSource": 5,
+    "isSensitive": false
+   },
+   {
+    "synonyms": [],
+    "configName": "message.format.version",
+    "configValue": "0.10.2-IV0",
+    "readOnly": false,
+    "configSource": 4,
+    "isSensitive": false
+   },
+   {
+    "synonyms": [],
+    "configName": "file.delete.delay.ms",
+    "configValue": "60000",
+    "readOnly": false,
+    "configSource": 5,
+    "isSensitive": false
+   },
+   {
+    "synonyms": [],
+    "configName": "leader.replication.throttled.replicas",
+    "configValue": "",
+    "readOnly": false,
+    "configSource": 5,
+    "isSensitive": false
+   },
+   {
+    "synonyms": [],
+    "configName": "max.message.bytes",
+    "configValue": "1000012",
+    "readOnly": false,
+    "configSource": 5,
+    "isSensitive": false
+   },
+    ...
+  ],
+  "resourceType": "2",
+  "resourceName": "my-topic-name"
+ }
+]
+
+```
+
 # Troubleshooting / FAQ
 
 ## HighLevelProducer with KeyedPartitioner errors on first send
@@ -1316,6 +1393,12 @@ KAFKA_VERSION=0.9 npm test
 KAFKA_VERSION=0.10 npm test
 
 KAFKA_VERSION=0.11 npm test
+
+KAFKA_VERSION=1.0 npm test
+
+KAFKA_VERSION=1.1 npm test
+
+KAFKA_VERSION=2.0 npm test
 ```
 
 *See Docker hub [tags](https://hub.docker.com/r/wurstmeister/kafka/tags/) entry for which version is considered `latest`.

--- a/README.md
+++ b/README.md
@@ -1169,7 +1169,7 @@ const payload = {
   includeSynonyms: false   // requires kafka 2.0+
 };
 
-admin.describeConfigs([payload], (err, res) => {
+admin.describeConfigs(payload, (err, res) => {
   console.log(JSON.stringify(res,null,1));
 })
 ```

--- a/README.md
+++ b/README.md
@@ -1159,13 +1159,17 @@ Example:
 
 ```js
 const resource = {
-  resourceType: '2',        // '2' for topic, '4' for broker
+  resourceType: admin.RESOURCE_TYPES.topic,   // 'broker' or 'topic'
   resourceName: 'my-topic-name',
   configNames: []           // specific config names, or empty array to return all,
-  includeSynonyms: false,   // requires kafka 2.0+
 }
 
-admin.describeConfigs([resource], (err, res) => {
+const payload = {
+  resources: [resource],
+  includeSynonyms: false   // requires kafka 2.0+
+};
+
+admin.describeConfigs([payload], (err, res) => {
   console.log(JSON.stringify(res,null,1));
 })
 ```

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var KafkaClient = require('./kafkaClient');
-var util = require('util');
-var EventEmitter = require('events');
+const KafkaClient = require('./kafkaClient');
+const resources = require('./resources');
+const util = require('util');
+const EventEmitter = require('events');
 
 function Admin (kafkaClient) {
   EventEmitter.call(this);
@@ -12,6 +13,7 @@ function Admin (kafkaClient) {
 
   var self = this;
   this.client = kafkaClient;
+  this.RESOURCE_TYPES = resources.RESOURCE_TYPES;
   this.ready = this.client.ready;
   this.client.on('ready', function () {
     self.ready = true;
@@ -50,12 +52,12 @@ Admin.prototype.createTopics = function (topics, cb) {
   this.client.createTopics(topics, cb);
 };
 
-Admin.prototype.describeConfigs = function (resources, cb) {
+Admin.prototype.describeConfigs = function (payload, cb) {
   if (!this.ready) {
-    this.once('ready', () => this.describeConfigs(resources, cb));
+    this.once('ready', () => this.describeConfigs(payload, cb));
     return;
   }
-  this.client.describeConfigs(resources, cb);
+  this.client.describeConfigs(payload, cb);
 };
 
 module.exports = Admin;

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -50,4 +50,12 @@ Admin.prototype.createTopics = function (topics, cb) {
   this.client.createTopics(topics, cb);
 };
 
+Admin.prototype.describeConfigs = function (resources, cb) {
+  if (!this.ready) {
+    this.once('ready', () => this.describeConfigs(resources, cb));
+    return;
+  }
+  this.client.describeConfigs(resources, cb);
+};
+
 module.exports = Admin;

--- a/lib/errors/InvalidRequestError.js
+++ b/lib/errors/InvalidRequestError.js
@@ -1,0 +1,18 @@
+const util = require('util');
+
+/**
+ * The request was invalid for a specific reason.
+ *
+ * @param {*} message A message describing the issue.
+ *
+ * @constructor
+ */
+const InvalidRequest = function (message) {
+  Error.captureStackTrace(this, this);
+  this.message = message;
+};
+
+util.inherits(InvalidRequest, Error);
+InvalidRequest.prototype.name = 'InvalidRequest';
+
+module.exports = InvalidRequest;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -6,6 +6,7 @@ module.exports = {
   FailedToRebalanceConsumerError: require('./FailedToRebalanceConsumerError'),
   InvalidConfigError: require('./InvalidConfigError'),
   SaslAuthenticationError: require('./SaslAuthenticationError'),
+  InvalidRequestError: require('./InvalidRequestError'),
   ConsumerGroupErrors: [
     require('./GroupCoordinatorNotAvailableError'),
     require('./GroupLoadInProgressError'),

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1227,4 +1227,35 @@ KafkaClient.prototype.handleReceivedData = function (socket) {
   }
 };
 
+KafkaClient.prototype.describeConfigs = function (resources, callback) {
+  if (!this.ready) {
+    return callback(new Error('Client is not ready (describeConfigs)'));
+  }
+  const brokers = this.brokerMetadata;
+  async.mapValuesLimit(
+    brokers,
+    this.options.maxAsyncRequests,
+    (brokerMetadata, brokerId, cb) => {
+      const broker = this.brokerForLeader(brokerId);
+      if (!broker || !broker.isConnected()) {
+        return cb(new errors.BrokerNotAvailableError('Broker not available (describeConfigs)'));
+      }
+
+      const correlationId = this.nextId();
+
+      const apiVersion = Math.min(broker.apiSupport.describeConfigs.max, 2);
+      const request = protocol.encodeDescribeConfigsRequest(this.clientId, correlationId, resources, apiVersion);
+      this.sendWhenReady(broker, correlationId, request, protocol.decodeDescribeConfigsResponse(apiVersion), cb);
+    },
+    (err, results) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      results = _.values(results);
+      callback(null, _.merge.apply({}, results));
+    }
+  );
+};
+
 module.exports = KafkaClient;

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -22,6 +22,7 @@ const baseProtocolVersions = protocolVersions.baseSupport;
 const apiMap = protocolVersions.apiMap;
 const NestedError = require('nested-error-stacks');
 const getCodec = require('./codec');
+const resourceTypeMap = require('./resources').resourceTypeMap;
 
 const DEFAULTS = {
   kafkaHost: 'localhost:9092',
@@ -1227,9 +1228,21 @@ KafkaClient.prototype.handleReceivedData = function (socket) {
   }
 };
 
-KafkaClient.prototype.describeConfigs = function (resources, callback) {
+KafkaClient.prototype.describeConfigs = function (payload, callback) {
   if (!this.ready) {
     return callback(new Error('Client is not ready (describeConfigs)'));
+  }
+  let err;
+  _.forEach(payload.resources, function (resource) {
+    if (resourceTypeMap[resource.resourceType] === undefined) {
+      err = new Error(`Unexpected resource type ${resource.resourceType} for resource ${resource.resourceName}`);
+      return false;
+    } else {
+      resource.resourceType = resourceTypeMap[resource.resourceType];
+    }
+  });
+  if (err) {
+    return callback(err);
   }
   const brokers = this.brokerMetadata;
   async.mapValuesLimit(
@@ -1248,7 +1261,7 @@ KafkaClient.prototype.describeConfigs = function (resources, callback) {
         apiVersion = broker.apiSupport.describeConfigs.max;
       }
       apiVersion = Math.min(apiVersion, 2);
-      const request = protocol.encodeDescribeConfigsRequest(this.clientId, correlationId, resources, apiVersion);
+      const request = protocol.encodeDescribeConfigsRequest(this.clientId, correlationId, payload, apiVersion);
       this.sendWhenReady(broker, correlationId, request, protocol.decodeDescribeConfigsResponse(apiVersion), cb);
     },
     (err, results) => {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1243,7 +1243,11 @@ KafkaClient.prototype.describeConfigs = function (resources, callback) {
 
       const correlationId = this.nextId();
 
-      const apiVersion = Math.min(broker.apiSupport.describeConfigs.max, 2);
+      let apiVersion = 0;
+      if (broker.apiSupport && broker.apiSupport.describeConfigs) {
+        apiVersion = broker.apiSupport.describeConfigs.max;
+      }
+      apiVersion = Math.min(apiVersion, 2);
       const request = protocol.encodeDescribeConfigsRequest(this.clientId, correlationId, resources, apiVersion);
       this.sendWhenReady(broker, correlationId, request, protocol.decodeDescribeConfigsResponse(apiVersion), cb);
     },

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -13,6 +13,7 @@ var PartitionMetadata = protocol.PartitionMetadata;
 const API_KEY_TO_NAME = _.invert(REQUEST_TYPE);
 const MessageSizeTooLarge = require('../errors/MessageSizeTooLargeError');
 const SaslAuthenticationError = require('../errors/SaslAuthenticationError');
+const InvalidRequestError = require('../errors/InvalidRequestError');
 
 var API_VERSION = 0;
 var REPLICA_ID = -1;
@@ -1504,6 +1505,139 @@ function decodeVersionsResponse (resp) {
   return error || versions;
 }
 
+function encodeDescribeConfigsRequest (clientId, correlationId, payload, apiVersion) {
+  let request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.describeConfigs, apiVersion);
+  const resources = payload.resources;
+  request.Int32BE(resources.length);
+  resources.forEach(function (resource) {
+    request.Int8(resource.resourceType);
+    request.Int16BE(resource.resourceName.length);
+    request.string(resource.resourceName);
+    if (resource.configNames === null || (Array.isArray(resource.configNames) && resource.configNames.length === 0)) {
+      request.Int32BE(-1); // -1 will fetch all config entries for the resource
+    } else {
+      request.Int32BE(resource.configNames.length);
+      resource.configNames.forEach(function (configName) {
+        request.Int16BE(configName.length).string(configName);
+      });
+    }
+  });
+  if (apiVersion > 0) {
+    request.Int8(payload.includeSynonyms || 0);
+  }
+
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeDescribeConfigsResponse (apiVersion) {
+  return function (resp) {
+    return _decodeDescribeConfigsResponse(resp, apiVersion);
+  };
+}
+
+function _decodeDescribeConfigsResponse (resp, apiVersion) {
+  let resources = [];
+  let error;
+  Binary.parse(resp)
+    .word32bs('size')
+    .word32bs('correlationId')
+    .word32bs('throttleTime')
+    .word32bs('resourceNum')
+    .loop(decodeResources);
+
+  function decodeResources (end, vars) {
+    if (vars.resourceNum-- === 0) return end();
+    let resource = { configEntries: [] };
+
+    this.word16bs('errorCode')
+      .word16bs('errorMessage')
+      .tap(function (vars) {
+        if (vars.errorCode !== 0) {
+          if (vars.errorMessage === -1) {
+            vars.errorMessage = '';
+          } else {
+            this.buffer('errorMessage', vars.errorMessage);
+            vars.errorMessage = vars.errorMessage.toString();
+          }
+          error = vars.errorCode === 42 ? new InvalidRequestError(vars.errorMessage) : createGroupError(vars.errorCode);
+        }
+      })
+      .word8bs('resourceType')
+      .word16bs('resourceName')
+      .tap(function (vars) {
+        this.buffer('resourceName', vars.resourceName);
+        resource.resourceType = vars.resourceType.toString();
+        resource.resourceName = vars.resourceName.toString();
+      })
+      .word32bs('configEntriesNum')
+      .loop(decodeConfigEntries)
+      .tap(function () {
+        resources.push(resource);
+      });
+
+    function decodeConfigEntries (end, vars) {
+      if (vars.configEntriesNum === -1 || vars.configEntriesNum-- === 0) return end();
+      let configEntry = { synonyms: [] };
+
+      this.word16bs('configName')
+        .tap(function (vars) {
+          this.buffer('configName', vars.configName);
+          configEntry.configName = vars.configName.toString();
+        })
+        .word16bs('configValue')
+        .tap(function (vars) {
+          if (vars.configValue === -1) {
+            vars.configValue = '';
+          } else {
+            this.buffer('configValue', vars.configValue);
+            vars.configValue = vars.configValue.toString();
+          }
+          configEntry.configValue = vars.configValue;
+        })
+        .word8bs('readOnly')
+        .word8bs('configSource')
+        .word8bs('isSensitive')
+        .tap(function () {
+          if (apiVersion > 0) {
+            this.word32bs('configSynonymsNum');
+            this.loop(decodeConfigSynonyms);
+          }
+        })
+        .tap(function (vars) {
+          configEntry.readOnly = Boolean(vars.readOnly);
+          configEntry.configSource = vars.configSource;
+          configEntry.isSensitive = Boolean(vars.isSensitive);
+          resource.configEntries.push(configEntry);
+        });
+
+      function decodeConfigSynonyms (end, vars) {
+        if (vars.configSynonymsNum === -1 || vars.configSynonymsNum-- === 0) return end();
+        let configSynonym = {};
+        this.word16bs('configSynonymName')
+          .tap(function (vars) {
+            this.buffer('configSynonymName', vars.configSynonymName);
+            configSynonym.configSynonymName = vars.configSynonymName.toString();
+          })
+          .word16bs('configSynonymValue')
+          .tap(function (vars) {
+            if (vars.configSynonymValue === -1) {
+              configSynonym.configSynonymValue = '';
+            } else {
+              this.buffer('configSynonymValue', vars.configSynonymValue);
+              configSynonym.configSynonymValue = vars.configSynonymValue.toString();
+            }
+          })
+          .word8bs('configSynonymSource')
+          .tap(function () {
+            configSynonym.configSynonymSource = vars.configSynonymSource.toString();
+            configEntry.synonyms.push(configSynonym);
+          });
+      }
+    }
+  }
+  return error || resources;
+}
+
 exports.encodeSaslHandshakeRequest = encodeSaslHandshakeRequest;
 exports.decodeSaslHandshakeResponse = decodeSaslHandshakeResponse;
 exports.encodeSaslAuthenticateRequest = encodeSaslAuthenticateRequest;
@@ -1558,3 +1692,5 @@ exports.encodeListGroups = encodeListGroups;
 exports.decodeListGroups = decodeListGroups;
 exports.encodeVersionsRequest = encodeVersionsRequest;
 exports.decodeVersionsResponse = decodeVersionsResponse;
+exports.encodeDescribeConfigsRequest = encodeDescribeConfigsRequest;
+exports.decodeDescribeConfigsResponse = decodeDescribeConfigsResponse;

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -47,6 +47,7 @@ const API_MAP = {
   apiVersions: [[p.encodeVersionsRequest, p.decodeVersionsResponse]],
   createTopics: null,
   deleteTopics: null,
+  describeConfigs: [[p.encodeDescribeConfigsRequest, p.decodeDescribeConfigsResponse]],
   saslAuthenticate: [[p.encodeSaslAuthenticationRequest, p.decodeSaslAuthenticationResponse]]
 };
 

--- a/lib/protocol/protocol_struct.js
+++ b/lib/protocol/protocol_struct.js
@@ -53,7 +53,8 @@ var ERROR_CODE = {
   '29': 'TopicAuthorizationFailed',
   '30': 'GroupAuthorizationFailed',
   '31': 'ClusterAuthorizationFailed',
-  '41': 'NotController'
+  '41': 'NotController',
+  '42': 'InvalidRequest'
 };
 
 var GROUP_ERROR = {
@@ -88,6 +89,7 @@ var REQUEST_TYPE = {
   apiVersions: 18,
   createTopics: 19,
   deleteTopics: 20,
+  describeConfigs: 32,
   saslAuthenticate: 36
 };
 

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const RESOURCE_TYPES = {
+  topic: 'topic',
+  broker: 'broker'
+};
+
+const resourceTypeMap = {
+  topic: 2,
+  broker: 4
+};
+
+module.exports = {
+  RESOURCE_TYPES,
+  resourceTypeMap
+};

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -3,6 +3,7 @@
 const Admin = require('../lib/admin');
 const ConsumerGroup = require('../lib/consumerGroup');
 const uuid = require('uuid');
+const should = require('should');
 
 describe('Admin', function () {
   describe('#listGroups', function () {
@@ -85,6 +86,131 @@ describe('Admin', function () {
         res[nonExistentGroup].should.have.property('members').with.lengthOf(0);
         res[nonExistentGroup].should.have.property('state', 'Dead');
         done(error);
+      });
+    });
+  });
+
+  describe('#describeConfigs', function () {
+    const createTopic = require('../docker/createTopic');
+    let admin, consumer;
+    const topic = uuid.v4();
+    const groupId = 'test-group-id';
+
+    before(function (done) {
+      if (process.env.KAFKA_VERSION === '0.8' || process.env.KAFKA_VERSION === '0.9' || process.env.KAFKA_VERSION === '0.10') {
+        this.skip();
+      }
+
+      createTopic(topic, 1, 1).then(function () {
+        consumer = new ConsumerGroup({
+          kafkaHost: 'localhost:9092',
+          groupId: groupId
+        }, topic);
+        consumer.once('connect', function () {
+          admin = new Admin(consumer.client);
+          done();
+        });
+      });
+    });
+
+    after(function (done) {
+      consumer.close(done);
+    });
+
+    it('should describe a list of topic configs', function (done) {
+      const request = {
+        resourceType: 2,
+        resourceName: topic,
+        configNames: []
+      };
+      const payload = {
+        includeSynonyms: false,
+        resources: [request]
+      };
+      admin.describeConfigs(payload, function (error, res) {
+        res.should.be.instanceof(Array);
+        res.length.should.be.exactly(1);
+        const entries = res[0];
+        entries.should.have.property('resourceType').and.exactly('2');
+        entries.should.have.property('resourceName').and.exactly(topic);
+        entries.should.have.property('configEntries');
+        entries.configEntries.length.should.be.greaterThan(1);
+        done(error);
+      });
+    });
+
+    it('should describe a list of broker configs for a specific broker id', function (done) {
+      const brokerName = '1001';
+      const request = {
+        resourceType: 4,
+        resourceName: brokerName,
+        configNames: []
+      };
+      const payload = {
+        includeSynonyms: false,
+        resources: [request]
+      };
+      admin.describeConfigs(payload, function (error, res) {
+        res.should.be.instanceof(Array);
+        res.length.should.be.exactly(1);
+        const entries = res[0];
+        entries.should.have.property('resourceType').and.exactly('4');
+        entries.should.have.property('resourceName').and.exactly(brokerName);
+        entries.should.have.property('configEntries');
+        entries.configEntries.length.should.be.greaterThan(1);
+        done(error);
+      });
+    });
+
+    it('should return an error if the resource (topic) doesnt exist', function (done) {
+      // TODO fix this before PR
+      const request = {
+        resourceType: 2,
+        resourceName: '',
+        configNames: []
+      };
+      const payload = {
+        includeSynonyms: false,
+        resources: [request]
+      };
+      admin.describeConfigs(payload, function (error, res) {
+        error.should.have.property('message').and.containEql('InvalidTopic');
+        done();
+      });
+    });
+
+    it('should return error if the resource (broker) doesnt exist', function (done) {
+      const brokerId = '9999';
+      const request = {
+        resourceType: 4,
+        resourceName: brokerId,
+        configNames: []
+      };
+      const payload = {
+        includeSynonyms: false,
+        resources: [request]
+      };
+      admin.describeConfigs(payload, function (error, res) {
+        should.not.exist(res);
+        error.should.have.property('message').and.containEql('Unexpected broker id');
+        done();
+      });
+    });
+
+    it('should return error for invalid resource type', function (done) {
+      const request = {
+        resourceType: 25,
+        resourceName: topic,
+        configNames: []
+      };
+      const payload = {
+        includeSynonyms: false,
+        resources: [request]
+      };
+      admin.describeConfigs(payload, function (error, res) {
+        should.not.exist(res);
+        error.should.have.property('message').and.equal(`Unexpected resource type UNKNOWN for resource ${topic}`);
+        done();
       });
     });
   });

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -5,7 +5,7 @@ const ConsumerGroup = require('../lib/consumerGroup');
 const uuid = require('uuid');
 const should = require('should');
 
-describe('Admin', function () {
+describe.only('Admin', function () {
   describe('#listGroups', function () {
     const createTopic = require('../docker/createTopic');
     let admin, consumer;
@@ -116,6 +116,8 @@ describe('Admin', function () {
     after(function (done) {
       if (consumer) {
         consumer.close(done);
+      } else {
+        done();
       }
     });
 

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -94,14 +94,14 @@ describe('Admin', function () {
   describe('#describeConfigs', function () {
     const createTopic = require('../docker/createTopic');
     let admin, client;
-    const topic = uuid.v4();
+    const topicName = uuid.v4();
 
     before(function (done) {
       if (['0.8', '0.9', '0.10'].includes(process.env.KAFKA_VERSION)) {
         this.skip();
       }
 
-      createTopic(topic, 1, 1).then(function () {
+      createTopic(topicName, 1, 1).then(function () {
         client = new KafkaClient({kafkaHost: 'localhost:9092'});
         admin = new Admin(client);
         admin.once('ready', done);
@@ -118,8 +118,8 @@ describe('Admin', function () {
 
     it('should describe a list of topic configs', function (done) {
       const request = {
-        resourceType: 2,
-        resourceName: topic,
+        resourceType: admin.RESOURCE_TYPES.topic,
+        resourceName: topicName,
         configNames: []
       };
       const payload = {
@@ -131,7 +131,7 @@ describe('Admin', function () {
         res.length.should.be.exactly(1);
         const entries = res[0];
         entries.should.have.property('resourceType').and.exactly('2');
-        entries.should.have.property('resourceName').and.exactly(topic);
+        entries.should.have.property('resourceName').and.exactly(topicName);
         entries.should.have.property('configEntries');
         entries.configEntries.length.should.be.greaterThan(1);
         done(error);
@@ -141,7 +141,7 @@ describe('Admin', function () {
     it('should describe a list of broker configs for a specific broker id', function (done) {
       const brokerName = '1001';
       const request = {
-        resourceType: 4,
+        resourceType: admin.RESOURCE_TYPES.broker,
         resourceName: brokerName,
         configNames: []
       };
@@ -163,7 +163,7 @@ describe('Admin', function () {
 
     it('should return an error if the resource (topic) doesnt exist', function (done) {
       const request = {
-        resourceType: 2,
+        resourceType: admin.RESOURCE_TYPES.topic,
         resourceName: '',
         configNames: []
       };
@@ -180,7 +180,7 @@ describe('Admin', function () {
     it('should return an error if the resource (broker) doesnt exist', function (done) {
       const brokerId = '9999';
       const request = {
-        resourceType: 4,
+        resourceType: admin.RESOURCE_TYPES.broker,
         resourceName: brokerId,
         configNames: []
       };
@@ -198,7 +198,7 @@ describe('Admin', function () {
     it('should return error for invalid resource type', function (done) {
       const request = {
         resourceType: 25,
-        resourceName: topic,
+        resourceName: topicName,
         configNames: []
       };
       const payload = {
@@ -207,7 +207,7 @@ describe('Admin', function () {
       };
       admin.describeConfigs(payload, function (error, res) {
         should.not.exist(res);
-        error.should.have.property('message').and.equal(`Unexpected resource type UNKNOWN for resource ${topic}`);
+        error.should.have.property('message').and.equal(`Unexpected resource type 25 for resource ${topicName}`);
         done();
       });
     });

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -163,7 +163,6 @@ describe('Admin', function () {
     });
 
     it('should return an error if the resource (topic) doesnt exist', function (done) {
-      // TODO fix this before PR
       const request = {
         resourceType: 2,
         resourceName: '',

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -114,7 +114,9 @@ describe('Admin', function () {
     });
 
     after(function (done) {
-      consumer.close(done);
+      if (consumer) {
+        consumer.close(done);
+      }
     });
 
     it('should describe a list of topic configs', function (done) {

--- a/test/test.admin.js
+++ b/test/test.admin.js
@@ -5,7 +5,7 @@ const ConsumerGroup = require('../lib/consumerGroup');
 const uuid = require('uuid');
 const should = require('should');
 
-describe.only('Admin', function () {
+describe('Admin', function () {
   describe('#listGroups', function () {
     const createTopic = require('../docker/createTopic');
     let admin, consumer;

--- a/test/test.protocol.js
+++ b/test/test.protocol.js
@@ -4,7 +4,7 @@ const versionSupport = require('../lib/protocol/protocolVersions');
 const protocolStruct = require('../lib/protocol/protocol_struct');
 const _ = require('lodash');
 
-describe.only('Protocol', function () {
+describe('Protocol', function () {
   it('exports correct properties', function () {
     versionSupport.should.have.property('apiMap');
     versionSupport.should.have.property('maxSupport');

--- a/test/test.protocol.js
+++ b/test/test.protocol.js
@@ -4,7 +4,7 @@ const versionSupport = require('../lib/protocol/protocolVersions');
 const protocolStruct = require('../lib/protocol/protocol_struct');
 const _ = require('lodash');
 
-describe('Protocol', function () {
+describe.only('Protocol', function () {
   it('exports correct properties', function () {
     versionSupport.should.have.property('apiMap');
     versionSupport.should.have.property('maxSupport');


### PR DESCRIPTION
This PR adds support for DescribeConfigs, which allows a user to get the config entries for either a broker or topic (aka resource).

@hyperlink let me know if you have any opinions on data format input/output.

https://kafka.apache.org/protocol#The_Messages_DescribeConfigs