### PR TITLE
Improvements to custom Partitioners for Producer

### DIFF
--- a/lib/baseProducer.js
+++ b/lib/baseProducer.js
@@ -9,6 +9,7 @@ var Message = protocol.Message;
 var KeyedMessage = protocol.KeyedMessage;
 var ProduceRequest = protocol.ProduceRequest;
 var partitioner = require('./partitioner');
+var Partitioner = partitioner.Partitioner;
 var DefaultPartitioner = partitioner.DefaultPartitioner;
 var RandomPartitioner = partitioner.RandomPartitioner;
 var CyclicPartitioner = partitioner.CyclicPartitioner;
@@ -41,15 +42,8 @@ var DEFAULTS = {
  *
  * @param {Client} client A kafka client object to use for the producer
  * @param {Object} [options] An object containing configuration options
- * @param {Number} [options.requireAcks=1] Configuration for when to consider a message as acknowledged.
- *      <li>0 = No ack required</li>
- *      <li>1 = Leader ack required</li>
- *      <li>-1 = All in sync replicas ack required</li>
- *
- * @param {Number} [options.ackTimeoutMs=100] The amount of time in milliseconds to wait for all acks before considered
- *      the message as errored
- * @param {Number} [defaultPartitionType] The default partitioner type
- * @param {Object} [customPartitioner] a custom partitinoer to use of the form: function (partitions, key)
+ * @param defaultPartitionerType
+ * @param {Object} [customPartitioner] a custom partitioner to use of the form: function (partitions, key)
  * @constructor
  */
 function BaseProducer (client, options, defaultPartitionerType, customPartitioner) {
@@ -68,10 +62,14 @@ function BaseProducer (client, options, defaultPartitionerType, customPartitione
     throw new Error('No customer partitioner defined');
   }
 
-  var partitionerType = PARTITIONER_MAP[options.partitionerType] || PARTITIONER_MAP[defaultPartitionerType];
+  if (customPartitioner instanceof Partitioner) {
+    this.partitioner = customPartitioner;
+  } else {
+    var partitionerType = PARTITIONER_MAP[options.partitionerType] || PARTITIONER_MAP[defaultPartitionerType];
 
-  // eslint-disable-next-line
-  this.partitioner = new partitionerType(customPartitioner);
+    // eslint-disable-next-line
+    this.partitioner = new partitionerType(customPartitioner);
+  }
 
   this.connect();
 }
@@ -125,7 +123,7 @@ BaseProducer.prototype.buildPayloads = function (payloads, topicMetadata) {
   payloads.forEach(p => {
     p.partition = p.hasOwnProperty('partition')
       ? p.partition
-      : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.key);
+      : this.partitioner.getPartition(_.map(topicMetadata[p.topic], 'partition'), p.key, p);
     p.attributes = p.hasOwnProperty('attributes') ? p.attributes : 0;
     let messages = _.isArray(p.messages) ? p.messages : [p.messages];
 

--- a/lib/highLevelProducer.js
+++ b/lib/highLevelProducer.js
@@ -5,7 +5,7 @@ var BaseProducer = require('./baseProducer');
 
 /** @inheritdoc */
 function HighLevelProducer (client, options, customPartitioner) {
-  BaseProducer.call(this, client, options, BaseProducer.PARTITIONER_TYPES.cyclic, customPartitioner);
+  BaseProducer.call(this, client, options, customPartitioner ? BaseProducer.PARTITIONER_TYPES.custom : BaseProducer.PARTITIONER_TYPES.cyclic, customPartitioner);
 }
 
 util.inherits(HighLevelProducer, BaseProducer);

--- a/lib/partitioner.js
+++ b/lib/partitioner.js
@@ -72,6 +72,7 @@ function CustomPartitioner (partitioner) {
 }
 util.inherits(CustomPartitioner, Partitioner);
 
+module.exports.Partitioner = Partitioner;
 module.exports.DefaultPartitioner = DefaultPartitioner;
 module.exports.CyclicPartitioner = CyclicPartitioner;
 module.exports.RandomPartitioner = RandomPartitioner;

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -5,7 +5,7 @@ var BaseProducer = require('./baseProducer');
 
 /** @inheritdoc */
 function Producer (client, options, customPartitioner) {
-  BaseProducer.call(this, client, options, BaseProducer.PARTITIONER_TYPES.default, customPartitioner);
+  BaseProducer.call(this, client, options, customPartitioner ? BaseProducer.PARTITIONER_TYPES.custom : BaseProducer.PARTITIONER_TYPES.default, customPartitioner);
 }
 
 util.inherits(Producer, BaseProducer);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,7 +23,7 @@ export class KafkaClient extends Client {
 }
 
 export class Producer {
-  constructor (client: Client, options?: ProducerOptions, customPartitioner?: CustomPartitioner);
+  constructor (client: Client, options?: ProducerOptions, customPartitioner?: Partitioner | CustomPartitioner);
 
   on (eventName: 'ready', cb: () => any): void;
   on (eventName: 'error', cb: (error: any) => any): void;
@@ -76,7 +76,7 @@ export class ConsumerGroupStream extends Readable {
 
   commit (message: Message, force?: boolean, cb?: (error: any, data: any) => any): void;
 
-  transmitMessages(): void;
+  transmitMessages (): void;
 
   close (cb: () => any): void;
 }
@@ -310,4 +310,8 @@ export class TopicsNotExistError extends Error {
   topics: string | string[];
 }
 
-export type CustomPartitioner = (partitions: number[], key: any) => number;
+export class Partitioner {
+  getPartition (partitions: number[], key: any, payload: ProduceRequest): number;
+}
+
+export type CustomPartitioner = (partitions: number[], key: any, payload: ProduceRequest) => number;


### PR DESCRIPTION
Allows passing your own Partitioner object directly,
and fixes setting default to custom for high level if
you pass in a custom partitioner

Also passes the entire payload to the custom partitioner
so that you can analyze the data of the payload to make judgement