### PR TITLE
TypeScript defs for idleConnection, maxAsyncRequests and sasl KafkaClient options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -178,6 +178,9 @@ export interface KafkaClientOptions {
   connectRetryOptions?: RetryOptions;
   sslOptions?: any;
   clientId?: string;
+  idleConnection?: number;
+  maxAsyncRequests?: number;
+  sasl?: any;
 }
 
 export interface ProducerStreamOptions {


### PR DESCRIPTION
This is a PR for #1035.

I have added definitions for the following `KafkaClient` options:

1. `idleConnection`
2. `maxAsyncRequests`
3. `sasl`