### PR TITLE
add sslOptions to ConsumerGroupOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -246,6 +246,7 @@ export interface ConsumerGroupOptions {
   zk?: ZKOptions;
   batch?: AckBatchOptions;
   ssl?: boolean;
+  sslOptions?: any;
   id?: string;
   groupId: string;
   sessionTimeout?: number;


### PR DESCRIPTION
This seems to be necessary to allow configuring SSL options with ConsumerGroups in Typescript. It does work, but it's not part of the type.