### PR TITLE
Allow specifying an encoding for ConsumerGroup (fixes #1131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ var options = {
   // An array of partition assignment protocols ordered by preference.
   // 'roundrobin' or 'range' string for built ins (see below to pass in custom assignment protocol)
   protocol: ['roundrobin'],
+  encoding: 'utf8', // default is utf8, use 'buffer' for binary data
 
   // Offsets to use for new groups other options could be 'earliest' or 'none' (none will emit an error if no offsets were saved)
   // equivalent to Java client's auto.offset.reset

--- a/lib/consumerGroup.js
+++ b/lib/consumerGroup.js
@@ -51,7 +51,8 @@ const DEFAULTS = {
   migrateRolling: true,
   onRebalance: null,
   topicPartitionCheckInterval: 30000,
-  protocol: ['roundrobin']
+  protocol: ['roundrobin'],
+  encoding: 'utf8'
 };
 
 function ConsumerGroup (memberOptions, topics) {


### PR DESCRIPTION
This allows 'buffer' to be specified so that binary data to be consumed via ConsumerGroup without corruption, resolving issue #1131