### PR TITLE
perf: use a much faster crc32 library turbo-crc32

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -3,7 +3,7 @@
 var Binary = require('binary');
 var Buffermaker = require('buffermaker');
 var _ = require('lodash');
-var crc32 = require('buffer-crc32');
+var crc32 = require('turbo-crc32/crc32');
 var protocol = require('./protocol_struct');
 var getCodec = require('../codec');
 var REQUEST_TYPE = protocol.REQUEST_TYPE;
@@ -792,7 +792,7 @@ function encodeMessage (message, magic) {
   setValueOnBuffer(m, value);
 
   m = m.make();
-  var crc = crc32.signed(m);
+  var crc = crc32(m) >> 0;
   return new Buffermaker().Int32BE(crc).string(m).make();
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "async": "^2.5.0",
     "binary": "~0.3.0",
     "bl": "^1.2.0",
-    "buffer-crc32": "~0.2.5",
     "buffermaker": "~1.2.0",
     "debug": "^2.1.3",
     "denque": "^1.3.0",
@@ -33,6 +32,7 @@
     "node-zookeeper-client": "~0.2.2",
     "optional": "^0.1.3",
     "retry": "^0.10.1",
+    "turbo-crc32": "^1.0.0",
     "uuid": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
`turbo-crc32` is about 3x times faster than `buffer-crc32`.

```
crc:            987.866ms
buffer-crc32:   1387.205ms
turbo-crc32:    447.711ms
```