### PR TITLE
Add describe config to kafkaclient

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -42,6 +42,22 @@ Admin.prototype.describeGroups = function (consumerGroups, cb) {
   this.client.getDescribeGroups(consumerGroups, cb);
 };
 
+Admin.prototype.getTopicConfigs = function (topicNames, configNames, callback) {
+  if (!this.ready) {
+    this.once('ready', () => this.client.getTopicConfigs(topicNames, configNames, callback));
+    return;
+  }
+  this.client.getTopicConfigs(topicNames, configNames, callback);
+};
+
+Admin.prototype.getClusterConfigs = function (brokerId, configNames, cb) {
+  if (!this.ready) {
+    this.once('ready', () => this.client.getClusterConfigs(brokerId, configNames, cb));
+    return;
+  }
+  this.client.getClusterConfigs(brokerId, configNames, cb);
+};
+
 Admin.prototype.createTopics = function (topics, cb) {
   if (!this.ready) {
     this.once('ready', () => this.client.createTopics(topics, cb));

--- a/lib/errors/ApiNotSupportedError.js
+++ b/lib/errors/ApiNotSupportedError.js
@@ -1,0 +1,17 @@
+var util = require('util');
+
+/**
+ * The broker did not support the requested API.
+ *
+ *
+ * @constructor
+ */
+var ApiNotSupportedError = function () {
+  Error.captureStackTrace(this, this);
+  this.message = 'The API is not supported by the receiving broker';
+};
+
+util.inherits(ApiNotSupportedError, Error);
+ApiNotSupportedError.prototype.name = 'ApiNotSupportedError';
+
+module.exports = ApiNotSupportedError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ApiNotSupportedError: require('./ApiNotSupportedError'),
   BrokerNotAvailableError: require('./BrokerNotAvailableError'),
   TopicsNotExistError: require('./TopicsNotExistError'),
   FailedToRegisterConsumerError: require('./FailedToRegisterConsumerError'),

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -887,6 +887,41 @@ KafkaClient.prototype.loadMetadataForTopics = function (topics, callback) {
 };
 
 /**
+ * Fetch configuration for one or more topics.
+ * Note - Kafka clusters of version < 2.0+ the default set of configs are returned for toipcs that do not exist. For 2.0+ an error is returned.
+ * @param {topicNames} topicNames Array of topic names.
+ * @param {configNames} configNames Array of config names to fetch. A null value will fetch all configs.
+ * @param {callback} callback Function to call once operation is completed.
+ */
+KafkaClient.prototype.getTopicConfigs = function (topicNames, configNames, callback) {
+  return this.describeConfigs(protocol.RESOURCE_TYPE.Topic, topicNames, configNames, callback);
+};
+
+/**
+ * Fetch configuration for a broker
+ * @param {brokerId} id Id the broker.
+ * @param {configNames} configNames Array of config names to fetch. A null value will fetch all configs.
+ * @param {callback} callback Function to call once operation is completed.
+ */
+KafkaClient.prototype.getClusterConfigs = function (brokerId, configNames, callback) {
+  return this.describeConfigs(protocol.RESOURCE_TYPE.Cluster, [brokerId], configNames, callback);
+};
+
+KafkaClient.prototype.describeConfigs = function (resourceType, resourceName, configNames, callback) {
+  switch (resourceType) {
+    // When requesting broker configs, we need to talk to that specific broker
+    case protocol.RESOURCE_TYPE.Cluster:
+      this.sendRequestToBroker([resourceName[0]], 'describeConfigs', [resourceType, resourceName, configNames], callback);
+      break;
+    case protocol.RESOURCE_TYPE.Topic:
+      this.sendRequestToAnyBroker('describeConfigs', [resourceType, resourceName, configNames], callback);
+      break;
+    default:
+      return callback(new Error('Invalid resource type'));
+  }
+};
+
+/**
  * Creates one or more topics.
  * @param {Array} topics Array of topics with partition and replication factor to create.
  * @param {createTopicsCallback} callback Function to call once operation is completed.
@@ -940,7 +975,13 @@ function compress (payloads, callback) {
 
 function getSupportedForRequestType (broker, requestType) {
   assert(!_.isEmpty(broker.apiSupport), 'apiSupport is empty');
-  const usable = broker.apiSupport[requestType].usable;
+  const brokerSupport = broker.apiSupport[requestType];
+
+  if (!brokerSupport) {
+    return null;
+  }
+
+  const usable = brokerSupport.usable;
 
   const combo = apiMap[requestType][usable];
   return {
@@ -1096,6 +1137,66 @@ KafkaClient.prototype.wrapControllerCheckIfNeeded = function (encoder, decoder, 
   wrappedCallback.isControllerWrapper = true;
 
   return wrappedCallback;
+};
+
+/**
+ * Sends a request to any broker in the cluster
+ */
+KafkaClient.prototype.sendRequestToAnyBroker = function (requestType, args, callback) {
+  // For now just select the first broker
+  const brokerId = Object.keys(this.brokerMetadata)[0];
+  this.sendRequestToBroker(brokerId, requestType, args, callback);
+};
+
+/**
+ * Sends a request to a specific broker by id
+ */
+KafkaClient.prototype.sendRequestToBroker = function (brokerId, requestType, args, callback) {
+  const brokerMetadata = this.brokerMetadata[brokerId];
+
+  if (!brokerMetadata) {
+    return callback(new Error('No broker with id ' + brokerId));
+  }
+
+  const broker = this.getBroker(brokerMetadata.host, brokerMetadata.port);
+
+  async.waterfall([
+    (callback) => {
+      if (broker.isReady()) {
+        return callback(null, broker);
+      }
+
+      this.connectToBroker(brokerMetadata, callback);
+    },
+    (broker, callback) => {
+      if (broker.isReady()) {
+        return callback(null, broker);
+      }
+
+      this.waitUntilReady(broker, (error) => {
+        callback(error, broker);
+      });
+    }
+  ],
+  (error, result) => {
+    if (error) {
+      return callback(error);
+    }
+
+    const correlationId = this.nextId();
+    const coder = getSupportedForRequestType(result, requestType);
+
+    if (!coder) {
+      return callback(new errors.ApiNotSupportedError());
+    }
+
+    args.unshift(this.clientId, correlationId);
+    const encoder = coder.encoder;
+    const decoder = coder.decoder;
+    const request = encoder.apply(null, args);
+
+    this.sendWhenReady(result, correlationId, request, decoder, callback);
+  });
 };
 
 KafkaClient.prototype.sendControllerRequest = function (encoder, decoder, encoderArgs, callback) {

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -199,6 +199,14 @@ function decodeFetchResponseV1 (cb, maxTickMessages) {
   };
 }
 
+function createErrorWithMessage (errorCode, errorMessage) {
+  if (errorCode == null || errorCode === 0 || !errorMessage) {
+    return null;
+  }
+
+  return new Error('Kafka error code' + errorCode + ', ' + errorMessage);
+}
+
 function createGroupError (errorCode) {
   if (errorCode == null || errorCode === 0) {
     return null;
@@ -408,6 +416,107 @@ function decodeMessageSet (topic, partition, messageSet, enqueue, emit, highWate
     if (partial) break;
     messageSet = messageSet.slice(cur);
   }
+}
+
+function encodeDescribeConfigsRequest (clientId, correlationId, type, names, configNames) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.describeConfigs, 0);
+
+  request.Int32BE(names.length);
+  names.forEach(function (name) {
+    request.Int8(type);
+    request.Int16BE(name.length).string(name);
+
+    if (configNames == null) {
+      request.Int32BE(-1);
+    } else {
+      request.Int32BE(configNames.length);
+      configNames.forEach(function (configName) {
+        request.Int16BE(configName.length).string(configName);
+      });
+    }
+  });
+
+  return encodeRequestWithLength(request.make());
+}
+
+function decodeDescribeConfigsRequest (resp) {
+  var result = {
+  };
+  var error;
+  var configEntries;
+
+  Binary.parse(resp)
+  .word32bs('size')
+  .word32bs('correlationId')
+  .word32bs('throttleTime')
+  .word32bs('resourceNum')
+  .loop(decodeResource);
+
+  function decodeResource (end, vars) {
+    if (vars.resourceNum-- === 0) return end();
+
+    this.word16bs('errorCode')
+      .word16bs('errorMessage')
+      .tap(function (vars) {
+        if (vars.errorMessage === -1) {
+          return;
+        }
+
+        this.buffer('errorMessage', vars.errorMessage);
+        vars.errorMessage = vars.errorMessage.toString();
+      })
+      .word8bs('resourceType')
+      .word16bs('resourceName')
+      .tap(function (vars) {
+        this.buffer('resourceName', vars.resourceName);
+        vars.resourceName = vars.resourceName.toString();
+      })
+      .word32bs('configEntriesNum')
+      .tap(function (vars) {
+        if (vars.errorCode !== 0 && vars.errorMessage) {
+          error = createErrorWithMessage(vars.errorCode, vars.errorMessage);
+        } else if (vars.errorCode !== 0) {
+          error = createGroupError(vars.errorCode);
+        }
+
+        configEntries = [];
+        this.loop(decodeConfigEntries);
+        result[vars.resourceName] = configEntries;
+      });
+  }
+
+  function decodeConfigEntries (end, vars) {
+    if (vars.configEntriesNum-- === 0) return end();
+
+    this.word16bs('configName')
+      .tap(function (vars) {
+        this.buffer('configName', vars.configName);
+        vars.configName = vars.configName.toString();
+      })
+      .word16bs('configValue')
+      .tap(function (vars) {
+        if (vars.configValue === -1) {
+          return;
+        }
+
+        this.buffer('configValue', vars.configValue);
+        vars.configValue = vars.configValue.toString();
+      })
+      .word8bs('readOnly')
+      .word8bs('default')
+      .word8bs('sensitive')
+      .tap(function (vars) {
+        configEntries.push({
+          name: vars.configName,
+          value: vars.configValue,
+          readOnly: vars.readOnly === 1,
+          default: vars.default === 1,
+          sensitive: vars.sensitive === 1
+        });
+      });
+  }
+
+  return error || result;
 }
 
 function encodeMetadataRequest (clientId, correlationId, topics) {
@@ -1595,6 +1704,9 @@ exports.decodeMetadataV1Response = decodeMetadataV1Response;
 
 exports.encodeCreateTopicRequest = encodeCreateTopicRequest;
 exports.decodeCreateTopicResponse = decodeCreateTopicResponse;
+
+exports.encodeDescribeConfigsRequest = encodeDescribeConfigsRequest;
+exports.decodeDescribeConfigsRequest = decodeDescribeConfigsRequest;
 
 exports.encodeProduceRequest = encodeProduceRequest;
 exports.encodeProduceV1Request = encodeProduceV1Request;

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -47,6 +47,7 @@ const API_MAP = {
   apiVersions: [[p.encodeVersionsRequest, p.decodeVersionsResponse]],
   createTopics: null,
   deleteTopics: null,
+  describeConfigs: [[p.encodeDescribeConfigsRequest, p.decodeDescribeConfigsRequest]],
   saslAuthenticate: [[p.encodeSaslAuthenticationRequest, p.decodeSaslAuthenticationResponse]]
 };
 

--- a/lib/protocol/protocol_struct.js
+++ b/lib/protocol/protocol_struct.js
@@ -88,7 +88,19 @@ var REQUEST_TYPE = {
   apiVersions: 18,
   createTopics: 19,
   deleteTopics: 20,
+  describeConfigs: 32,
   saslAuthenticate: 36
+};
+
+// Not documented in protocol - https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+var RESOURCE_TYPE = {
+  Unknown: 0,
+  Any: 1,
+  Topic: 2,
+  Group: 3,
+  Cluster: 4,
+  TransactionalId: 5,
+  DelegationToken: 6
 };
 
 Object.keys(KEYS).forEach(function (o) {
@@ -98,6 +110,7 @@ exports.KEYS = KEYS;
 exports.ERROR_CODE = ERROR_CODE;
 exports.GROUP_ERROR = GROUP_ERROR;
 exports.REQUEST_TYPE = REQUEST_TYPE;
+exports.RESOURCE_TYPE = RESOURCE_TYPE;
 exports.KeyedMessage = function KeyedMessage (key, value) {
   exports.Message.call(this, 0, 0, key, value, Date.now());
 };


### PR DESCRIPTION
This allows fetching configs for topics and brokers, using the describe configs API (https://kafka.apache.org/protocol#The_Messages_DescribeConfigs).

Exposed as 3 methods on KafkaClient - `describeConfigs` which is a low level access to the API, and getTopicConfigs and getClusterConfigs on top. The request is supported on 0.11+.

As part of this there are a couple of new ways to send requests to brokers that are not with payloads.

Example use:

```
var kafka = require('..');
var client = new kafka.KafkaClient({
  kafkaHost: '127.0.0.1:9092'
});

client.on('ready', () => {
  // Get a broker ID and pass null for config names to get all
  const brokerId = Object.keys(client.brokerMetadata)[0];
  client.getClusterConfigs(brokerId, null, (err, result) => {
    console.log(result[brokerId]);
  });

  client.getTopicConfigs(['ExampleTopic', 'RebalanceTopic'], ['compression.type', 'message.format.version'], (err, result) => {
    console.log(result['ExampleTopic']);
    console.log(result['RebalanceTopic']);
  });
});

```