### PR TITLE
feat: add createTopics to KafkaClient for d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,8 @@ export class Client {
 
 export class KafkaClient extends Client {
   constructor (options?: KafkaClientOptions);
-
+  
+  createTopics(topics: string[], cb: (error: any, data: any) => any): void;
   connect (): void;
 }
 


### PR DESCRIPTION
Hi, when I was using `kafkaClient`, I noticed that the `createTopics` method hint was missing.