### PR TITLE
Add config entries and replica assignment to create topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,30 @@ var topicsToCreate = [{
 {
   topic: 'topic2',
   partitions: 5,
-  replicationFactor: 3
+  replicationFactor: 3,
+  // Optional set of config entries
+  configEntries: [
+    {
+      name: 'compression.type',
+      value: 'gzip'
+    },
+    {
+      name: 'min.compaction.lag.ms',
+      value: '50'
+    }
+  ],
+  // Optional explicit partition / replica assignment
+  // When this property exists, partitions and replicationFactor properties are ignored
+  replicaAssignment: [ 
+    {
+      partition: 0,
+      replicas: [3, 4]
+    },
+    {
+      partition: 1,
+      replicas: [2, 1]
+    }
+  ]
 }];
 
 client.createTopics(topics, (error, result) => {

--- a/lib/errors/ApiNotSupportedError.js
+++ b/lib/errors/ApiNotSupportedError.js
@@ -1,0 +1,17 @@
+var util = require('util');
+
+/**
+ * The broker did not support the requested API.
+ *
+ *
+ * @constructor
+ */
+var ApiNotSupportedError = function () {
+  Error.captureStackTrace(this, this);
+  this.message = 'The API is not supported by the receiving broker';
+};
+
+util.inherits(ApiNotSupportedError, Error);
+ApiNotSupportedError.prototype.name = 'ApiNotSupportedError';
+
+module.exports = ApiNotSupportedError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ApiNotSupportedError: require('./ApiNotSupportedError'),
   BrokerNotAvailableError: require('./BrokerNotAvailableError'),
   TopicsNotExistError: require('./TopicsNotExistError'),
   FailedToRegisterConsumerError: require('./FailedToRegisterConsumerError'),

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -257,7 +257,7 @@ KafkaClient.prototype.getController = function (callback) {
     var controller = this.brokerMetadata[this.clusterMetadata.controllerId];
     var broker = this.getBroker(controller.host, controller.port);
 
-    return callback(null, broker);
+    return callback(null, broker, this.clusterMetadata.controllerId);
   }
 
   // If cached controller is not available, refresh metadata
@@ -898,10 +898,7 @@ KafkaClient.prototype.createTopics = function (topics, callback) {
     return Client.prototype.createTopics.apply(this, arguments);
   }
 
-  const encoder = protocol.encodeCreateTopicRequest;
-  const decoder = protocol.decodeCreateTopicResponse;
-
-  this.sendControllerRequest(encoder, decoder, [topics, this.options.requestTimeout], callback);
+  this.sendControllerRequest('createTopics', [topics, this.options.requestTimeout], callback);
 };
 
 KafkaClient.prototype.topicExists = function (topics, callback) {
@@ -941,7 +938,13 @@ function compress (payloads, callback) {
 
 function getSupportedForRequestType (broker, requestType) {
   assert(!_.isEmpty(broker.apiSupport), 'apiSupport is empty');
-  const usable = broker.apiSupport[requestType].usable;
+  const brokerSupport = broker.apiSupport[requestType];
+
+  if (!brokerSupport) {
+    return null;
+  }
+
+  const usable = brokerSupport.usable;
 
   const combo = apiMap[requestType][usable];
   return {
@@ -1048,6 +1051,61 @@ KafkaClient.prototype.sendRequest = function (request, callback) {
   );
 };
 
+/**
+ * Sends a request to a specific broker by id
+ */
+KafkaClient.prototype.sendRequestToBroker = function (brokerId, requestType, args, callback) {
+  const brokerMetadata = this.brokerMetadata[brokerId];
+
+  if (!brokerMetadata) {
+    return callback(new Error('No broker with id ' + brokerId));
+  }
+
+  const broker = this.getBroker(brokerMetadata.host, brokerMetadata.port);
+
+  async.waterfall([
+    (callback) => {
+      if (broker.isReady()) {
+        return callback(null, broker);
+      }
+
+      if (broker.isConnected()) {
+        return callback(null, broker);
+      }
+
+      this.connectToBroker(brokerMetadata, callback);
+    },
+    (broker, callback) => {
+      if (broker.isReady()) {
+        return callback(null, broker);
+      }
+
+      this.waitUntilReady(broker, (error) => {
+        callback(error, broker);
+      });
+    }
+  ],
+  (error, result) => {
+    if (error) {
+      return callback(error);
+    }
+
+    const correlationId = this.nextId();
+    const coder = getSupportedForRequestType(result, requestType);
+
+    if (!coder) {
+      return callback(new errors.ApiNotSupportedError());
+    }
+
+    args.unshift(this.clientId, correlationId);
+    const encoder = coder.encoder;
+    const decoder = coder.decoder;
+    const request = encoder.apply(null, args);
+
+    this.sendWhenReady(result, correlationId, request, decoder, callback);
+  });
+};
+
 KafkaClient.prototype.leaderLessPayloads = function (payloads) {
   return _.filter(payloads, payload => !this.hasMetadata(payload.topic, payload.partition));
 };
@@ -1073,7 +1131,7 @@ KafkaClient.prototype.verifyPayloadsHasLeaders = function (payloads, callback) {
   });
 };
 
-KafkaClient.prototype.wrapControllerCheckIfNeeded = function (encoder, decoder, encoderArgs, callback) {
+KafkaClient.prototype.wrapControllerCheckIfNeeded = function (requestType, requestArgs, callback) {
   if (callback.isControllerWrapper) {
     return callback;
   }
@@ -1086,7 +1144,7 @@ KafkaClient.prototype.wrapControllerCheckIfNeeded = function (encoder, decoder, 
 
       if (!hasBeenInvoked) {
         hasBeenInvoked = true;
-        this.sendControllerRequest(encoder, decoder, encoderArgs, wrappedCallback);
+        this.sendControllerRequest(requestType, requestArgs, wrappedCallback);
         return;
       }
     }
@@ -1099,22 +1157,17 @@ KafkaClient.prototype.wrapControllerCheckIfNeeded = function (encoder, decoder, 
   return wrappedCallback;
 };
 
-KafkaClient.prototype.sendControllerRequest = function (encoder, decoder, encoderArgs, callback) {
-  this.getController((error, controller) => {
+KafkaClient.prototype.sendControllerRequest = function (requestType, args, callback) {
+  this.getController((error, controller, controllerId) => {
     if (error) {
       return callback(error);
     }
 
-    const originalArgs = _.clone(encoderArgs);
+    const originalArgs = _.clone(args);
     const originalCallback = callback;
-    const correlationId = this.nextId();
-    encoderArgs.unshift(this.clientId, correlationId);
-    const request = encoder.apply(null, encoderArgs);
+    callback = this.wrapControllerCheckIfNeeded(requestType, originalArgs, originalCallback);
 
-    callback = this.wrapControllerCheckIfNeeded(encoder, decoder, originalArgs, originalCallback);
-
-    this.queueCallback(controller.socket, correlationId, [decoder, callback]);
-    controller.write(request);
+    this.sendRequestToBroker(controllerId, requestType, args, callback);
   });
 };
 

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1069,17 +1069,6 @@ KafkaClient.prototype.sendRequestToBroker = function (brokerId, requestType, arg
         return callback(null, broker);
       }
 
-      if (broker.isConnected()) {
-        return callback(null, broker);
-      }
-
-      this.connectToBroker(brokerMetadata, callback);
-    },
-    (broker, callback) => {
-      if (broker.isReady()) {
-        return callback(null, broker);
-      }
-
       this.waitUntilReady(broker, (error) => {
         callback(error, broker);
       });
@@ -1090,8 +1079,9 @@ KafkaClient.prototype.sendRequestToBroker = function (brokerId, requestType, arg
       return callback(error);
     }
 
+    const broker = this.getBroker(brokerMetadata.host, brokerMetadata.port);
     const correlationId = this.nextId();
-    const coder = getSupportedForRequestType(result, requestType);
+    const coder = getSupportedForRequestType(broker, requestType);
 
     if (!coder) {
       return callback(new errors.ApiNotSupportedError());
@@ -1102,7 +1092,7 @@ KafkaClient.prototype.sendRequestToBroker = function (brokerId, requestType, arg
     const decoder = coder.decoder;
     const request = encoder.apply(null, args);
 
-    this.sendWhenReady(result, correlationId, request, decoder, callback);
+    this.sendWhenReady(broker, correlationId, request, decoder, callback);
   });
 };
 

--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -565,22 +565,75 @@ function _decodeMetadataResponse (resp, version) {
 }
 
 function encodeCreateTopicRequest (clientId, correlationId, topics, timeoutMs) {
-  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.createTopics, 1);
+  return _encodeCreateTopicRequest(clientId, correlationId, topics, timeoutMs, 0);
+}
+
+function encodeCreateTopicRequestV1 (clientId, correlationId, topics, timeoutMs) {
+  return _encodeCreateTopicRequest(clientId, correlationId, topics, timeoutMs, 1);
+}
+
+function _encodeCreateTopicRequest (clientId, correlationId, topics, timeoutMs, version) {
+  var request = encodeRequestHeader(clientId, correlationId, REQUEST_TYPE.createTopics, version);
   request.Int32BE(topics.length);
   topics.forEach(function (topic) {
     request.Int16BE(topic.topic.length).string(topic.topic);
-    request.Int32BE(topic.partitions);
-    request.Int16BE(topic.replicationFactor);
-    request.Int32BE(0);
-    request.Int32BE(0);
+
+    // When replica assignment is used, partitions and replication factor must be unset (-1)
+    if (topic.replicaAssignment) {
+      request.Int32BE(-1);
+      request.Int16BE(-1);
+    } else {
+      request.Int32BE(topic.partitions);
+      request.Int16BE(topic.replicationFactor);
+    }
+
+    if (topic.replicaAssignment) {
+      request.Int32BE(topic.replicaAssignment.length);
+      topic.replicaAssignment.forEach(function (replicaAssignment) {
+        request.Int32BE(replicaAssignment.partition);
+        request.Int32BE(replicaAssignment.replicas.length);
+        replicaAssignment.replicas.forEach(function (replica) {
+          request.Int32BE(replica);
+        });
+      });
+    } else {
+      request.Int32BE(0);
+    }
+
+    if (topic.configEntries) {
+      request.Int32BE(topic.configEntries.length);
+      topic.configEntries.forEach(function (config) {
+        request.Int16BE(config.name.length).string(config.name);
+
+        if (config.value == null) {
+          request.Int16BE(-1);
+        } else {
+          request.Int16BE(config.value.length).string(config.value);
+        }
+      });
+    } else {
+      request.Int32BE(0);
+    }
   });
   request.Int32BE(timeoutMs);
-  request.Int8(0);
+
+  // Validate only is 1+
+  if (version > 0) {
+    request.Int8(0);
+  }
 
   return encodeRequestWithLength(request.make());
 }
 
 function decodeCreateTopicResponse (resp) {
+  return _decodeCreateTopicResponse(resp, 0);
+}
+
+function decodeCreateTopicResponseV1 (resp) {
+  return _decodeCreateTopicResponse(resp, 1);
+}
+
+function _decodeCreateTopicResponse (resp, version) {
   var topicErrorResponses = [];
   var error;
 
@@ -599,8 +652,16 @@ function decodeCreateTopicResponse (resp) {
         vars.topic = vars.topic.toString();
       })
       .word16bs('errorCode')
-      .word16bs('errorMessage')
       .tap(function (vars) {
+        if (version > 0) {
+          this.word16bs('errorMessage');
+
+          if (vars.errorMessage !== -1) {
+            this.buffer('errorMessage', vars.errorMessage);
+            vars.errorMessage = vars.errorMessage.toString();
+          }
+        }
+
         if (vars.errorCode === 0) {
           return;
         }
@@ -612,13 +673,17 @@ function decodeCreateTopicResponse (resp) {
           return;
         }
 
-        this.buffer('errorMessage', vars.errorMessage);
-        vars.errorMessage = vars.errorMessage.toString();
-
-        topicErrorResponses.push({
-          topic: vars.topic,
-          error: vars.errorMessage
-        });
+        if (version > 0) {
+          topicErrorResponses.push({
+            topic: vars.topic,
+            error: vars.errorMessage
+          });
+        } else {
+          topicErrorResponses.push({
+            topic: vars.topic,
+            error: 'received error code ' + vars.errorCode + ' for topic'
+          });
+        }
       });
   }
 
@@ -1728,7 +1793,9 @@ exports.encodeMetadataV1Request = encodeMetadataV1Request;
 exports.decodeMetadataV1Response = decodeMetadataV1Response;
 
 exports.encodeCreateTopicRequest = encodeCreateTopicRequest;
+exports.encodeCreateTopicRequestV1 = encodeCreateTopicRequestV1;
 exports.decodeCreateTopicResponse = decodeCreateTopicResponse;
+exports.decodeCreateTopicResponseV1 = decodeCreateTopicResponseV1;
 
 exports.encodeProduceRequest = encodeProduceRequest;
 exports.encodeProduceV1Request = encodeProduceV1Request;

--- a/lib/protocol/protocolVersions.js
+++ b/lib/protocol/protocolVersions.js
@@ -45,7 +45,10 @@ const API_MAP = {
     [p.encodeSaslHandshakeRequest, p.decodeSaslHandshakeResponse]
   ],
   apiVersions: [[p.encodeVersionsRequest, p.decodeVersionsResponse]],
-  createTopics: null,
+  createTopics: [
+    [p.encodeCreateTopicRequest, p.decodeCreateTopicResponse],
+    [p.encodeCreateTopicRequestV1, p.decodeCreateTopicResponseV1]
+  ],
   deleteTopics: null,
   describeConfigs: [[p.encodeDescribeConfigsRequest, p.decodeDescribeConfigsResponse]],
   saslAuthenticate: [[p.encodeSaslAuthenticationRequest, p.decodeSaslAuthenticationResponse]]

--- a/test/test.kafkaClient.js
+++ b/test/test.kafkaClient.js
@@ -905,7 +905,7 @@ describe('Kafka Client', function () {
     let client;
 
     beforeEach(function (done) {
-      if (process.env.KAFKA_VERSION === '0.9') {
+      if (process.env.KAFKA_VERSION === '0.9' || process.env.KAFKA_VERSION === '0.10') {
         return this.skip();
       }
 
@@ -979,6 +979,147 @@ describe('Kafka Client', function () {
         done();
       });
     });
+
+    it('should create topics with config entries', function (done) {
+      const topic1 = uuid.v4();
+      const topic1ReplicationFactor = 1;
+      const topic1Partitions = 5;
+
+      client.createTopics([
+        {
+          topic: topic1,
+          partitions: topic1Partitions,
+          replicationFactor: topic1ReplicationFactor,
+          configEntries: [
+            {
+              name: 'compression.type',
+              value: 'gzip'
+            },
+            {
+              name: 'min.compaction.lag.ms',
+              value: '50'
+            }
+          ]
+        }
+      ], (error, result) => {
+        should.not.exist(error);
+        result.should.be.empty;
+
+        const resource = {
+          resourceType: 'topic',
+          resourceName: topic1,
+          configNames: []
+        };
+
+        const payload = {
+          resources: [resource]
+        };
+
+        client.describeConfigs(payload, (error, result) => {
+          should.not.exist(error);
+          result[0].resourceName.should.be.exactly(topic1);
+          result[0].configEntries.filter(c => { return c.configName === 'compression.type'; })[0].configValue.should.be.exactly('gzip');
+          result[0].configEntries.filter(c => { return c.configName === 'min.compaction.lag.ms'; })[0].configValue.should.be.exactly('50');
+          done();
+        });
+      });
+    });
+
+    it('should return topic creation errors with invalid config entries', function (done) {
+      const topic1 = uuid.v4();
+      const topic1ReplicationFactor = 1;
+      const topic1Partitions = 5;
+
+      client.createTopics([
+        {
+          topic: topic1,
+          partitions: topic1Partitions,
+          replicationFactor: topic1ReplicationFactor,
+          configEntries: [
+            {
+              name: 'compression.ty',
+              value: 'gzip'
+            }
+          ]
+        }
+      ], (error, result) => {
+        should.not.exist(error);
+        result.should.have.length(1);
+        result[0].topic.should.be.exactly(topic1);
+        result[0].error.toLowerCase().should.startWith('unknown topic config name: compression.ty');
+        done();
+      });
+    });
+
+    it('should create topics with explicit replica assignments if both simple and explicit assignment is provided', function (done) {
+      const topic1 = uuid.v4();
+      const topic1ReplicationFactor = 1;
+      const topic1Partitions = 5;
+
+      client.createTopics([
+        {
+          topic: topic1,
+          partitions: topic1Partitions,
+          replicationFactor: topic1ReplicationFactor,
+          replicaAssignment: [{
+            partition: 0,
+            replicas: [1001]
+          },
+          {
+            partition: 1,
+            replicas: [1001]
+          }]
+        }
+      ], (error, result) => {
+        should.not.exist(error);
+        result.should.be.empty;
+
+        client.loadMetadataForTopics([topic1], (error, result) => {
+          should.not.exist(error);
+
+          const topicMetadata = result[1].metadata[topic1];
+          Object.keys(topicMetadata).should.have.length(2);
+          topicMetadata['0'].partition.should.be.exactly(0);
+          topicMetadata['0'].replicas.should.have.length(1);
+          topicMetadata['1'].partition.should.be.exactly(1);
+          topicMetadata['1'].replicas.should.have.length(1);
+          done();
+        });
+      });
+    });
+
+    it('should create topics with replica assignments if only explicit assignment is provided', function (done) {
+      const topic1 = uuid.v4();
+
+      client.createTopics([
+        {
+          topic: topic1,
+          replicaAssignment: [{
+            partition: 0,
+            replicas: [1001]
+          },
+          {
+            partition: 1,
+            replicas: [1001]
+          }]
+        }
+      ], (error, result) => {
+        should.not.exist(error);
+        result.should.be.empty;
+
+        client.loadMetadataForTopics([topic1], (error, result) => {
+          should.not.exist(error);
+
+          const topicMetadata = result[1].metadata[topic1];
+          Object.keys(topicMetadata).should.have.length(2);
+          topicMetadata['0'].partition.should.be.exactly(0);
+          topicMetadata['0'].replicas.should.have.length(1);
+          topicMetadata['1'].partition.should.be.exactly(1);
+          topicMetadata['1'].replicas.should.have.length(1);
+          done();
+        });
+      });
+    });
   });
 
   describe('#wrapControllerCheckIfNeeded', function () {
@@ -1004,8 +1145,8 @@ describe('Kafka Client', function () {
     it('should not wrap again if already wrapped', function () {
       const fn = _.noop;
 
-      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fn);
-      const secondWrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], wrapped);
+      const wrapped = client.wrapControllerCheckIfNeeded('', [], fn);
+      const secondWrapped = client.wrapControllerCheckIfNeeded('', [], wrapped);
 
       wrapped.should.be.exactly(secondWrapped);
     });
@@ -1020,7 +1161,8 @@ describe('Kafka Client', function () {
 
     it('should set controller id to null if NotControllerError was returned once', function () {
       const fn = _.noop;
-      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fn);
+      const requestType = 'createTopics';
+      const wrapped = client.wrapControllerCheckIfNeeded(requestType, [], fn);
       const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
       sandbox.stub(client, 'sendControllerRequest');
 
@@ -1031,11 +1173,10 @@ describe('Kafka Client', function () {
     });
 
     it('should send controller request again if NotControllerError was returned once', function () {
-      var encoder = () => undefined;
-      var decoder = () => undefined;
       var args = [];
+      const requestType = 'createTopics';
       const fn = _.noop;
-      const wrapped = client.wrapControllerCheckIfNeeded(encoder, decoder, args, fn);
+      const wrapped = client.wrapControllerCheckIfNeeded(requestType, args, fn);
       const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
       const sendControllerRequestSpy = sandbox.stub(client, 'sendControllerRequest');
 
@@ -1044,12 +1185,13 @@ describe('Kafka Client', function () {
       sinon.assert.calledOnce(setControllerIdSpy);
       sinon.assert.alwaysCalledWithExactly(setControllerIdSpy, null);
       sinon.assert.calledOnce(sendControllerRequestSpy);
-      sinon.assert.alwaysCalledWithExactly(sendControllerRequestSpy, encoder, decoder, args, wrapped);
+      sinon.assert.alwaysCalledWithExactly(sendControllerRequestSpy, requestType, args, wrapped);
     });
 
     it('should set controller id to null and call original callback if NotControllerError was returned on second try', function () {
       const fnSpy = sandbox.spy();
-      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const requestType = 'createTopics';
+      const wrapped = client.wrapControllerCheckIfNeeded(requestType, [], fnSpy);
       const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
       sandbox.stub(client, 'sendControllerRequest');
 
@@ -1063,7 +1205,8 @@ describe('Kafka Client', function () {
 
     it('should call original callback if another error was returned', function () {
       const fnSpy = sandbox.spy();
-      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const requestType = 'createTopics';
+      const wrapped = client.wrapControllerCheckIfNeeded(requestType, [], fnSpy);
       const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
 
       wrapped(new TimeoutError('operation timed out'));
@@ -1074,7 +1217,8 @@ describe('Kafka Client', function () {
 
     it('should call original callback if no error was returned', function () {
       const fnSpy = sandbox.spy();
-      const wrapped = client.wrapControllerCheckIfNeeded(_.noop, _.noop, [], fnSpy);
+      const requestType = 'createTopics';
+      const wrapped = client.wrapControllerCheckIfNeeded(requestType, [], fnSpy);
       const setControllerIdSpy = sandbox.spy(client, 'setControllerId');
       const expectedResult = [];
 
@@ -1107,52 +1251,53 @@ describe('Kafka Client', function () {
     });
 
     it('should wrap callback', function () {
+      const requestType = 'createTopics';
       const fakeBroker = new BrokerWrapper(new FakeSocket());
-      sandbox.stub(client, 'getController').yields(null, fakeBroker);
+      sandbox.stub(client, 'getController').yields(null, fakeBroker, 1);
       sandbox.stub(client, 'queueCallback');
       const wrapControllerSpy = sandbox.spy(client, 'wrapControllerCheckIfNeeded');
       const callbackSpy = sandbox.spy();
 
-      client.sendControllerRequest(_.noop, _.noop, [], callbackSpy);
+      client.sendControllerRequest(requestType, [], callbackSpy);
 
       sinon.assert.calledOnce(wrapControllerSpy);
     });
 
     it('should be called twice when NotController error was returned', function () {
+      const requestType = 'createTopics';
       const fakeBroker = new BrokerWrapper(new FakeSocket());
-      sandbox.stub(client, 'getController').yields(null, fakeBroker);
-      sandbox.stub(client, 'queueCallback').callsFake((socket, correlationId, args) => {
-        args[1](new NotControllerError('not controller'));
+      sandbox.stub(client, 'getController').yields(null, fakeBroker, 1);
+      sandbox.stub(client, 'sendRequestToBroker').callsFake((brokerId, requestType, args, callback) => {
+        callback(new NotControllerError('not controller'));
       });
       const callbackSpy = sandbox.spy();
       const sendControllerRequestSpy = sandbox.spy(client, 'sendControllerRequest');
 
-      client.sendControllerRequest(_.noop, _.noop, [], callbackSpy);
+      client.sendControllerRequest(requestType, [], callbackSpy);
 
       sinon.assert.calledTwice(sendControllerRequestSpy);
     });
 
-    it('should call encoder and queue callback', function () {
+    it('should send request to controller', function () {
+      const requestType = 'createTopics';
       const fakeBroker = new BrokerWrapper(new FakeSocket());
-      sandbox.stub(client, 'getController').yields(null, fakeBroker);
-      const queueCallbackSpy = sandbox.stub(client, 'queueCallback');
-      const encoder = sandbox.spy();
-      const decoder = _.noop;
+      sandbox.stub(client, 'getController').yields(null, fakeBroker, 1);
+      const sendRequestSpy = sandbox.stub(client, 'sendRequestToBroker');
       const args = [];
       const callback = _.noop;
 
-      client.sendControllerRequest(encoder, decoder, args, callback);
+      client.sendControllerRequest(requestType, args, callback);
 
-      sinon.assert.calledOnce(encoder);
-      sinon.assert.calledOnce(queueCallbackSpy);
+      sinon.assert.calledOnce(sendRequestSpy);
     });
 
     it('should return error if controller request fails', function () {
+      const requestType = 'createTopics';
       const error = new TimeoutError('operation timed out');
       sandbox.stub(client, 'getController').yields(error);
       const callbackSpy = sandbox.spy();
 
-      client.sendControllerRequest(null, null, null, callbackSpy);
+      client.sendControllerRequest(requestType, null, callbackSpy);
 
       sinon.assert.calledOnce(callbackSpy);
       sinon.assert.alwaysCalledWithExactly(callbackSpy, error);


### PR DESCRIPTION
Adds support for providing config entries and explicit replica assignment
when creating new topics.

The existing create topic implementation has been cleaned up a bit,
as it didn't make use of the existing API support setup (it was fixed to protocol version 1).
As part of the cleanup, version 0 and 1 of the request is now supported.

The send controller request was also cleaned up a bit. A new function `sendRequestToBroker`
provides a more robust way to send requests to a specific broker now.

Create Topic tests now skips version 0.10. The new describe configs request is used to validate config entries. This request is supported from 0.11+.

This addition is backwards compatible.