### PR TITLE
Add connect event for HighLevelConsumer in types/index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,7 +94,7 @@ export class ConsumerGroup {
 
   on (eventName: 'message', cb: (message: Message) => any): void;
   on (eventName: 'error' | 'offsetOutOfRange', cb: (error: any) => any): void;
-  on (eventName: 'rebalancing' | 'rebalanced', cb: () => any): void;
+  on (eventName: 'rebalancing' | 'rebalanced' | 'connect', cb: () => any): void;
 
   addTopics (topics: string[] | Topic[], cb?: (error: any, added: string[] | Topic[]) => any): void;
 

--- a/types/kafka-node-tests.ts
+++ b/types/kafka-node-tests.ts
@@ -125,6 +125,7 @@ const cgOptions: kafka.ConsumerGroupOptions = {
 
 const consumerGroup = new kafka.ConsumerGroup(cgOptions, ['topic1']);
 consumerGroup.on('error', (err) => { });
+consumerGroup.on('connect', () => { });
 consumerGroup.on('message', (msg) => { });
 consumerGroup.close(true, (err: Error) => { });
 


### PR DESCRIPTION
ConsumerGroup and ConsumerGroupStream of kafka-node had already "connect" event .
But HighLevelConsumer in types/index.d.ts missed event for HighLevelConsumer.