### PR TITLE
Issue/#1019 Request timed out after 30000ms with increased load

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -487,8 +487,10 @@ KafkaClient.prototype.wrapTimeoutIfNeeded = function (socketId, correlationId, c
   }
 
   timeoutId = setTimeout(() => {
-    let isInQueu = this.unqueueCallback(socketId, correlationId);
-    if (!isInQueu) return ;
+    let wasInQueue = this.unqueueCallback(socketId, correlationId);
+    if (!wasInQueue) {
+      return;
+    }
     callback(new TimeoutError(`Request timed out after ${timeout}ms`));
     callback = _.noop;
   }, timeout);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -487,7 +487,8 @@ KafkaClient.prototype.wrapTimeoutIfNeeded = function (socketId, correlationId, c
   }
 
   timeoutId = setTimeout(() => {
-    this.unqueueCallback(socketId, correlationId);
+    let isInQueu = this.unqueueCallback(socketId, correlationId);
+    if (!isInQueu) return ;
     callback(new TimeoutError(`Request timed out after ${timeout}ms`));
     callback = _.noop;
   }, timeout);


### PR DESCRIPTION
This pull request should solve the issue #1019 
**The issue root cause:**
if you require a request timeout and require ack, the kafka-node will queue your callback in a queue and start a timer. This issue happens when the event queue has a lot of requests to handle -like in case of load test- so the event loop takes a lot of time to handle the recieved ack from the kafka and the timer will timeout and a timeout exception will fire although the kafka has sent the ack and the service received it successfully.
**solution**
this solution checks the return value of unqueueCallback method, if it is equal 'null' this means handleReceivedData method has handled this request and unqueue it before so it will return without firing request timeout error.