### PR TITLE
Add missing sasl property to consumergroup type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -233,6 +233,7 @@ export interface ConsumerGroupOptions {
   batch?: AckBatchOptions;
   ssl?: boolean;
   sslOptions?: any;
+  sasl?: any;
   id?: string;
   groupId: string;
   sessionTimeout?: number;


### PR DESCRIPTION
The options object are passed along to the kafka client constructor, so this property goes here as well. Currently not possible to use sasl for consumers when using typescript.