### PR TITLE
Fix ConsumerGroupStream commit payload type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ export class ConsumerGroupStream extends Readable {
 
   constructor (options: ConsumerGroupStreamOptions, topics: string | string[]);
 
-  commit (message: Message, force?: boolean, cb?: (error: any, data: any) => any): void;
+  commit (commits: OffsetCommitRequest, force?: boolean, cb?: (error: any, data: any) => any): void;
 
   transmitMessages (): void;
 
@@ -120,7 +120,7 @@ export class Offset {
 
   fetch (payloads: OffsetRequest[], cb: (error: any, data: any) => any): void;
 
-  commit (groupId: string, payloads: OffsetCommitRequest[], cb: (error: any, data: any) => any): void;
+  commit (groupId: string, commits: OffsetCommitRequest[], cb: (error: any, data: any) => any): void;
 
   fetchCommits (groupId: string, payloads: OffsetFetchRequest[], cb: (error: any, data: any) => any): void;
 


### PR DESCRIPTION
Currently, the payload argument for the `commit`
method is declared as type `Message` interface which
in turn expects a `value` field that offset requests do
not have (This forces workarounds like inserting a dummy
value to get around the type-checker).

This patch fixes this by specifying the commit payload
to be of type `OffsetCommitRequest` which declares
the sufficient fields of commit payloads.