### PR TITLE
Fixed bug when autoCommit arguments length equal 0

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -158,7 +158,7 @@ function autoCommit (force, cb) {
     force = false;
   }
 
-  if (this.committing && !force) return cb(null, 'Offset committing');
+  if (this.committing && !force && cb) return cb(null, 'Offset committing');
 
   this.committing = true;
   setTimeout(function () {


### PR DESCRIPTION
fixed when  autoCommit function arguments.length = 0, the cb is not defined

issue:[Consumer autoCommit cb is a not function](https://github.com/SOHU-Co/kafka-node/issues/1291)