### PR TITLE
Update kafkaClient.js

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1253,7 +1253,7 @@ KafkaClient.prototype.sendFetchRequest = function (
       logger.error(
         'ignoring message due to it being from an old group - memberId: ' + memberId,
         '!=' + consumer.memberId + ' - generationId: ' + generationId + '!=' + consumer.generationId,
-        `or closing: ${consumer.closing} rebalancing: ${consumer.rebalancing} connecting: ${consumer.connecting}`
+        ' or consumer state with closing: ' + consumer.closing + ' rebalancing: ' + consumer.rebalancing + ' connecting: ' + consumer.connecting
       );
       return false;
     }

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -1252,7 +1252,8 @@ KafkaClient.prototype.sendFetchRequest = function (
     ) {
       logger.error(
         'ignoring message due to it being from an old group - memberId: ' + memberId,
-        '!=' + consumer.memberId + ' - generationId: ' + generationId + '!=' + consumer.generationId
+        '!=' + consumer.memberId + ' - generationId: ' + generationId + '!=' + consumer.generationId,
+        `or closing: ${consumer.closing} rebalancing: ${consumer.rebalancing} connecting: ${consumer.connecting}`
       );
       return false;
     }


### PR DESCRIPTION
just to make sure not confusing with error message without log information.

After change
`
(kafkaClient.js:1247:stateValidator) ignoring message due to it being from an old group - memberId: hostname.013e98ab1bd1!=hostname.013e98ab1bd1 - generationId: 530!=530 or closing: undefined rebalancing: true connecting: false CallStack:    at stateValidator (/usr/src/app/node_modules/kafka-node/lib/kafkaClient.js:1247:14)
`
before change
`
(kafkaClient.js:1247:stateValidator) ignoring message due to it being from an old group - memberId: hostname.013e98ab1bd1!=hostname.013e98ab1bd1 - generationId: 530!=530 CallStack:    at stateValidator (/usr/src/app/node_modules/kafka-node/lib/kafkaClient.js:1247:14)
`
I am not sure whether 'ignoring message' is really right term, if event is rebalancing, isn't this will be consumed when rebalancing finished?
