### PR TITLE
Add Errors to the exports

### DIFF
--- a/kafka.js
+++ b/kafka.js
@@ -16,3 +16,4 @@ exports.CyclicPartitioner = require('./lib/partitioner').CyclicPartitioner;
 exports.RandomPartitioner = require('./lib/partitioner').RandomPartitioner;
 exports.KeyedPartitioner = require('./lib/partitioner').KeyedPartitioner;
 exports.CustomPartitioner = require('./lib/partitioner').CustomPartitioner;
+exports.Errors = require('./lib/errors');

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -16,5 +16,6 @@ module.exports = {
     require('./NotCoordinatorForGroupError'),
     require('./RebalanceInProgressError'),
     require('./UnknownMemberIdError')
-  ]
+  ],
+  TimeoutError: require('./TimeoutError')
 };


### PR DESCRIPTION
This PR adds all the error types to the export list, this then allows the use of the error types to do things like:

```javascript
import { KafkaClient, Producer, Errors } from 'kafka-node';

const client = new KafkaClient({});
const producer = new Producer(client);

const errorHandler = (error) => {
  switch (error.constructor) {
    case Errors.TimeoutError:
      console.error('Timeout error');
      break;
    case Errors.TopicsNotExistError:
      console.error('Topics not exist error');
      break;
    default:
      console.error(`Any other error`);
  }
}

producer.on('error', errorHandler);
```