### PR TITLE
TLS SNI

### DIFF
--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -714,7 +714,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   var self = this;
   var socket;
   if (self.ssl) {
-    const sslOptionsData = { ...self.sslOptions };
+    let sslOptionsData = Object.assign({}, self.sslOptions);
     sslOptionsData.servername = host;
     socket = tls.connect(port, host, sslOptionsData);
   } else {

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -714,9 +714,8 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   var self = this;
   var socket;
   if (self.ssl) {
-    const sslOptionsData = { ... self.sslOptions }
-    sslOptionsData.servername = host
-        
+    const sslOptionsData = { ... self.sslOptions };
+    sslOptionsData.servername = host;
     socket = tls.connect(port, host, sslOptionsData);
   } else {
     socket = net.createConnection(port, host);

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -714,7 +714,10 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   var self = this;
   var socket;
   if (self.ssl) {
-    socket = tls.connect(port, host, self.sslOptions);
+    const sslOptionsData = { ... self.sslOptions }
+    sslOptionsData.servername = host
+        
+    socket = tls.connect(port, host, sslOptionsData);
   } else {
     socket = net.createConnection(port, host);
   }

--- a/lib/kafkaClient.js
+++ b/lib/kafkaClient.js
@@ -714,7 +714,7 @@ KafkaClient.prototype.createBroker = function (host, port, longpolling) {
   var self = this;
   var socket;
   if (self.ssl) {
-    const sslOptionsData = { ... self.sslOptions };
+    const sslOptionsData = { ...self.sslOptions };
     sslOptionsData.servername = host;
     socket = tls.connect(port, host, sslOptionsData);
   } else {


### PR DESCRIPTION
KafkaClient didn't send the SNI (Server Name Indication) which broker try to connect.

https://nodejs.org/api/tls.html#tls_tls_connect_options_callback

I need to do a copy to not change the original options to not create a problem with the concurrency. I can't send this information in the original parameter, because we can connect in multiple brokers and need to send the current broker that I trying to connect

