### PR TITLE
Fix offset in messageSet needs to be incremental

### DIFF
--- a/lib/protocol/protocol.js
+++ b/lib/protocol/protocol.js
@@ -867,9 +867,12 @@ function _encodeProduceRequest (clientId, correlationId, payloads, requireAcks, 
 
 function encodeMessageSet (messageSet, magic) {
   var buffer = new Buffermaker();
+  let offset = 0;
   messageSet.forEach(function (message) {
     var msg = encodeMessage(message, magic);
-    buffer.Int64BE(0).Int32BE(msg.length).string(msg);
+    buffer.Int64BE(offset).Int32BE(msg.length).string(msg);
+    // offset in messageSet needs to be incremental
+    offset += 1;
   });
   return buffer.make();
 }


### PR DESCRIPTION
* reference link: https://github.com/apache/kafka/pull/6785
* when sending compression message to Kafka 2.4, offset field which is always 0 could cause "InvalidRecordException" error