### PR TITLE
Vulnerability - Upgrade bl to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "^2.6.2",
     "binary": "~0.3.0",
-    "bl": "^2.2.0",
+    "bl": "^2.2.1",
     "buffer-crc32": "~0.2.5",
     "buffermaker": "~1.2.0",
     "debug": "^2.1.3",


### PR DESCRIPTION
There was a vulnerability fixed in `bl@2.2.1`. It was also fixed in `3.0.1` and `4.0.3` but just bumping from `2.2.0` to `2.2.1` seems less risky here.
> Affected versions of this package are vulnerable to Remote Memory Exposure. If user input ends up in consume() argument and can become negative, BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.